### PR TITLE
fix: avoid codebase-retrieval timeouts and release search DB handles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,14 @@
 // 配置必须最先加载（包含环境变量初始化）
 import './config.js';
 
-import { promises as fs } from 'node:fs';
+import fsSync, { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import cac from 'cac';
 import { generateProjectId } from './db/index.js';
 import { type ScanStats, scan } from './scanner/index.js';
+import { withLock } from './utils/lock.js';
 import { logger } from './utils/logger.js';
 
 // 读取 package.json 获取版本号
@@ -17,6 +18,37 @@ const pkgPath = path.resolve(__dirname, '../package.json');
 const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8'));
 
 const cli = cac('contextweaver');
+
+function getCliIndexLockTimeoutMs(): number {
+  const raw = process.env.CW_INDEX_LOCK_TIMEOUT_MS;
+  if (!raw) {
+    return process.env.CW_BACKGROUND_INDEX === '1' ? 500 : 10 * 60 * 1000;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 10 * 60 * 1000;
+}
+
+function registerBackgroundIndexMarkerCleanup(): void {
+  const markerPath = process.env.CW_BACKGROUND_INDEX_MARKER_PATH;
+  if (!markerPath) {
+    return;
+  }
+
+  const cleanup = () => {
+    try {
+      if (fsSync.existsSync(markerPath)) {
+        fsSync.unlinkSync(markerPath);
+      }
+    } catch {
+      // 忽略清理失败，避免影响主流程退出
+    }
+  };
+
+  process.on('exit', cleanup);
+}
+
+registerBackgroundIndexMarkerCleanup();
 
 // 自定义版本输出，只显示版本号
 if (process.argv.includes('-v') || process.argv.includes('--version')) {
@@ -103,8 +135,6 @@ cli
     const startTime = Date.now();
 
     try {
-      const { withLock } = await import('./utils/lock.js');
-
       // 进度日志节流：只在 30%、60%、90% 时输出（100% 由扫描完成日志代替）
       let lastLoggedPercent = 0;
       const stats: ScanStats = await withLock(
@@ -123,7 +153,7 @@ cli
               }
             },
           }),
-        10 * 60 * 1000,
+        getCliIndexLockTimeoutMs(),
       );
 
       process.stdout.write('\n');
@@ -135,6 +165,10 @@ cli
       );
     } catch (err) {
       const error = err as { message?: string; stack?: string };
+      if (process.env.CW_BACKGROUND_INDEX === '1' && error.message?.includes('无法获取项目锁')) {
+        logger.info('后台索引已由其他进程处理，当前进程退出');
+        process.exit(0);
+      }
       logger.error({ err, stack: error.stack }, `索引失败: ${error.message}`);
       process.exit(1);
     }
@@ -180,13 +214,11 @@ cli
 
       const { handleCodebaseRetrieval } = await import('./mcp/tools/codebaseRetrieval.js');
 
-      const response = await handleCodebaseRetrieval(
-        {
-          repo_path: repoPath,
-          information_request: informationRequest,
-          technical_terms: technicalTerms.length > 0 ? technicalTerms : undefined,
-        },
-      );
+      const response = await handleCodebaseRetrieval({
+        repo_path: repoPath,
+        information_request: informationRequest,
+        technical_terms: technicalTerms.length > 0 ? technicalTerms : undefined,
+      });
 
       const text = response.content.map((item) => item.text).join('\n');
       process.stdout.write(`${text}\n`);

--- a/src/mcp/tools/codebaseRetrieval.ts
+++ b/src/mcp/tools/codebaseRetrieval.ts
@@ -8,9 +8,11 @@
  * - 回归代理本能：工具只负责定位，跨文件探索由 Agent 自主发起
  */
 
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { generateProjectId } from '../../db/index.js';
 // 注意：SearchService 和 scan 改为延迟导入，避免在 MCP 启动时就加载 native 模块
@@ -46,6 +48,8 @@ export type CodebaseRetrievalInput = z.infer<typeof codebaseRetrievalSchema>;
 
 const BASE_DIR = path.join(os.homedir(), '.contextweaver');
 const INDEX_LOCK_TIMEOUT_MS = 10 * 60 * 1000;
+const BACKGROUND_INDEX_COOLDOWN_MS = 60 * 1000;
+const backgroundIndexStartedAt = new Map<string, number>();
 
 /**
  * 确保默认 .env 文件存在
@@ -100,6 +104,54 @@ function isProjectIndexed(projectId: string): boolean {
 }
 
 /**
+ * 后台索引预约文件路径
+ */
+function getBackgroundIndexRequestPath(projectId: string): string {
+  return path.join(BASE_DIR, projectId, 'background-index.request');
+}
+
+/**
+ * 预约后台索引任务，避免多个 MCP 进程反复拉起子进程
+ */
+function claimBackgroundIndexRequest(projectId: string): string | null {
+  const requestPath = getBackgroundIndexRequestPath(projectId);
+  const dir = path.dirname(requestPath);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  try {
+    const content = fs.readFileSync(requestPath, 'utf-8');
+    const requestInfo = JSON.parse(content) as { pid: number; timestamp: number };
+    if (Date.now() - requestInfo.timestamp < BACKGROUND_INDEX_COOLDOWN_MS) {
+      return null;
+    }
+  } catch {
+    // 文件不存在或损坏时，继续重建预约文件
+  }
+
+  try {
+    fs.unlinkSync(requestPath);
+  } catch {
+    // 允许文件不存在
+  }
+
+  try {
+    fs.writeFileSync(requestPath, JSON.stringify({ pid: process.pid, timestamp: Date.now() }), {
+      flag: 'wx',
+    });
+    return requestPath;
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code !== 'EEXIST') {
+      logger.debug({ error: error.message }, '创建后台索引请求标记失败');
+    }
+    return null;
+  }
+}
+
+/**
  * 确保代码库已索引
  *
  * 策略：
@@ -120,37 +172,97 @@ async function ensureIndexed(
   const { withLock } = await import('../../utils/lock.js');
   const { scan } = await import('../../scanner/index.js');
 
-  await withLock(projectId, 'index', async () => {
-    const wasIndexed = isProjectIndexed(projectId);
+  await withLock(
+    projectId,
+    'index',
+    async () => {
+      const wasIndexed = isProjectIndexed(projectId);
 
-    if (!wasIndexed) {
+      if (!wasIndexed) {
+        logger.info(
+          { repoPath, projectId: projectId.slice(0, 10) },
+          '代码库未初始化，开始首次索引...',
+        );
+        onProgress?.(0, 100, '代码库未索引，开始首次索引...');
+      } else {
+        logger.debug({ projectId: projectId.slice(0, 10) }, '执行增量索引...');
+      }
+
+      const startTime = Date.now();
+      const stats = await scan(repoPath, { vectorIndex: true, onProgress });
+      const elapsed = Date.now() - startTime;
+
       logger.info(
-        { repoPath, projectId: projectId.slice(0, 10) },
-        '代码库未初始化，开始首次索引...',
+        {
+          projectId: projectId.slice(0, 10),
+          isFirstTime: !wasIndexed,
+          totalFiles: stats.totalFiles,
+          added: stats.added,
+          modified: stats.modified,
+          deleted: stats.deleted,
+          vectorIndex: stats.vectorIndex,
+          elapsedMs: elapsed,
+        },
+        '索引完成',
       );
-      onProgress?.(0, 100, '代码库未索引，开始首次索引...');
-    } else {
-      logger.debug({ projectId: projectId.slice(0, 10) }, '执行增量索引...');
-    }
+    },
+    INDEX_LOCK_TIMEOUT_MS,
+  );
+}
 
-    const startTime = Date.now();
-    const stats = await scan(repoPath, { vectorIndex: true, onProgress });
-    const elapsed = Date.now() - startTime;
+/**
+ * 后台启动增量索引
+ */
+async function scheduleBackgroundIndex(repoPath: string, projectId: string): Promise<void> {
+  const lastStartedAt = backgroundIndexStartedAt.get(projectId) ?? 0;
+  if (Date.now() - lastStartedAt < BACKGROUND_INDEX_COOLDOWN_MS) {
+    return;
+  }
 
+  const { isProjectLocked } = await import('../../utils/lock.js');
+  if (isProjectLocked(projectId)) {
+    logger.debug({ projectId: projectId.slice(0, 10) }, '后台索引已在进行中，跳过重复调度');
+    return;
+  }
+
+  const requestPath = claimBackgroundIndexRequest(projectId);
+  if (!requestPath) {
+    logger.debug({ projectId: projectId.slice(0, 10) }, '后台索引请求已被其他进程预约');
+    return;
+  }
+
+  backgroundIndexStartedAt.set(projectId, Date.now());
+
+  try {
+    const cliEntry = fileURLToPath(new URL('./index.js', import.meta.url));
+    const child = spawn(process.execPath, [cliEntry, 'index', repoPath], {
+      detached: true,
+      stdio: 'ignore',
+      env: {
+        ...process.env,
+        CW_BACKGROUND_INDEX: '1',
+        CW_INDEX_LOCK_TIMEOUT_MS: '500',
+        CW_BACKGROUND_INDEX_MARKER_PATH: requestPath,
+      },
+    });
+
+    child.unref();
     logger.info(
       {
         projectId: projectId.slice(0, 10),
-        isFirstTime: !wasIndexed,
-        totalFiles: stats.totalFiles,
-        added: stats.added,
-        modified: stats.modified,
-        deleted: stats.deleted,
-        vectorIndex: stats.vectorIndex,
-        elapsedMs: elapsed,
+        pid: child.pid,
       },
-      '索引完成',
+      '已启动后台增量索引',
     );
-  }, INDEX_LOCK_TIMEOUT_MS);
+  } catch (err) {
+    try {
+      fs.unlinkSync(requestPath);
+    } catch {
+      // 忽略清理失败
+    }
+
+    throw err;
+  }
 }
 
 // 工具处理函数
@@ -195,8 +307,16 @@ export async function handleCodebaseRetrieval(
   // 1. 生成项目 ID（与 CLI 保持一致：路径 + 目录创建时间）
   const projectId = generateProjectId(repo_path);
 
-  // 2. 确保代码库已索引（自动初始化 + 增量更新）
-  await ensureIndexed(repo_path, projectId, onProgress);
+  // 2. 首次使用时同步建索引；已有索引时优先查询旧索引并异步增量更新
+  if (!isProjectIndexed(projectId)) {
+    await ensureIndexed(repo_path, projectId, onProgress);
+  } else {
+    logger.debug({ projectId: projectId.slice(0, 10) }, '命中已有索引，跳过同步增量索引');
+    void scheduleBackgroundIndex(repo_path, projectId).catch((err) => {
+      const error = err as { message?: string };
+      logger.warn({ projectId: projectId.slice(0, 10), error: error.message }, '启动后台索引失败');
+    });
+  }
 
   // 3. 合并查询
   // - information_request 驱动语义向量搜索
@@ -216,63 +336,67 @@ export async function handleCodebaseRetrieval(
 
   // 5. 创建 SearchService 实例
   const service = new SearchService(projectId, repo_path);
-  await service.init();
-  logger.debug('SearchService 初始化完成');
+  try {
+    await service.init();
+    logger.debug('SearchService 初始化完成');
 
-  // 6. 执行搜索
-  const contextPack = await service.buildContextPack(query);
+    // 6. 执行搜索
+    const contextPack = await service.buildContextPack(query);
 
-  // 详细日志：seeds 信息
-  if (contextPack.seeds.length > 0) {
+    // 详细日志：seeds 信息
+    if (contextPack.seeds.length > 0) {
+      logger.info(
+        {
+          seeds: contextPack.seeds.map((s) => ({
+            file: s.filePath,
+            chunk: s.chunkIndex,
+            score: s.score.toFixed(4),
+            source: s.source,
+          })),
+        },
+        'MCP 搜索 seeds',
+      );
+    } else {
+      logger.warn('MCP 搜索无 seeds 命中');
+    }
+
+    // 详细日志：扩展结果
+    if (contextPack.expanded.length > 0) {
+      logger.debug(
+        {
+          expandedCount: contextPack.expanded.length,
+          expanded: contextPack.expanded.slice(0, 5).map((e) => ({
+            file: e.filePath,
+            chunk: e.chunkIndex,
+            score: e.score.toFixed(4),
+          })),
+        },
+        'MCP 扩展结果 (前5)',
+      );
+    }
+
+    // 详细日志：打包后的文件段落
     logger.info(
       {
-        seeds: contextPack.seeds.map((s) => ({
-          file: s.filePath,
-          chunk: s.chunkIndex,
-          score: s.score.toFixed(4),
-          source: s.source,
-        })),
-      },
-      'MCP 搜索 seeds',
-    );
-  } else {
-    logger.warn('MCP 搜索无 seeds 命中');
-  }
-
-  // 详细日志：扩展结果
-  if (contextPack.expanded.length > 0) {
-    logger.debug(
-      {
+        seedCount: contextPack.seeds.length,
         expandedCount: contextPack.expanded.length,
-        expanded: contextPack.expanded.slice(0, 5).map((e) => ({
-          file: e.filePath,
-          chunk: e.chunkIndex,
-          score: e.score.toFixed(4),
+        fileCount: contextPack.files.length,
+        totalSegments: contextPack.files.reduce((acc, f) => acc + f.segments.length, 0),
+        files: contextPack.files.map((f) => ({
+          path: f.filePath,
+          segments: f.segments.length,
+          lines: f.segments.map((s) => `L${s.startLine}-${s.endLine}`),
         })),
+        timingMs: contextPack.debug?.timingMs,
       },
-      'MCP 扩展结果 (前5)',
+      'MCP codebase-retrieval 完成',
     );
+
+    // 7. 格式化输出
+    return formatMcpResponse(contextPack);
+  } finally {
+    service.close();
   }
-
-  // 详细日志：打包后的文件段落
-  logger.info(
-    {
-      seedCount: contextPack.seeds.length,
-      expandedCount: contextPack.expanded.length,
-      fileCount: contextPack.files.length,
-      totalSegments: contextPack.files.reduce((acc, f) => acc + f.segments.length, 0),
-      files: contextPack.files.map((f) => ({
-        path: f.filePath,
-        segments: f.segments.length,
-        lines: f.segments.map((s) => `L${s.startLine}-${s.endLine}`),
-      })),
-      timingMs: contextPack.debug?.timingMs,
-    },
-    'MCP codebase-retrieval 完成',
-  );
-
-  // 7. 格式化输出
-  return formatMcpResponse(contextPack);
 }
 
 // 响应格式化

--- a/src/search/ContextPacker.ts
+++ b/src/search/ContextPacker.ts
@@ -5,7 +5,7 @@
  * 最终输出适合 LLM 消费的上下文包。
  */
 
-import { initDb } from '../db/index.js';
+import { closeDb, initDb } from '../db/index.js';
 import type { ScoredChunk, SearchConfig, Segment } from './types.js';
 
 export class ContextPacker {
@@ -28,60 +28,64 @@ export class ContextPacker {
 
     // 2. 每个文件内合并区间 + 从原文件切片
     const db = initDb(this.projectId);
-    const result: Array<{ filePath: string; segments: Segment[] }> = [];
-    let totalChars = 0;
+    try {
+      const result: Array<{ filePath: string; segments: Segment[] }> = [];
+      let totalChars = 0;
 
-    // 按文件最高得分排序
-    const sortedFiles = Object.entries(byFile)
-      .map(([filePath, fileChunks]) => ({
-        filePath,
-        chunks: fileChunks,
-        maxScore: Math.max(...fileChunks.map((c) => c.score)),
-      }))
-      .sort((a, b) => b.maxScore - a.maxScore);
+      // 按文件最高得分排序
+      const sortedFiles = Object.entries(byFile)
+        .map(([filePath, fileChunks]) => ({
+          filePath,
+          chunks: fileChunks,
+          maxScore: Math.max(...fileChunks.map((c) => c.score)),
+        }))
+        .sort((a, b) => b.maxScore - a.maxScore);
 
-    // 性能优化：批量读取所有文件内容（N 次 SELECT → 1 次）
-    const allFilePaths = sortedFiles.map((f) => f.filePath);
-    const placeholders = allFilePaths.map(() => '?').join(',');
-    const rows = db
-      .prepare(`SELECT path, content FROM files WHERE path IN (${placeholders})`)
-      .all(...allFilePaths) as Array<{ path: string; content: string }>;
-    const contentMap = new Map(rows.map((r) => [r.path, r.content]));
+      // 性能优化：批量读取所有文件内容（N 次 SELECT → 1 次）
+      const allFilePaths = sortedFiles.map((f) => f.filePath);
+      const placeholders = allFilePaths.map(() => '?').join(',');
+      const rows = db
+        .prepare(`SELECT path, content FROM files WHERE path IN (${placeholders})`)
+        .all(...allFilePaths) as Array<{ path: string; content: string }>;
+      const contentMap = new Map(rows.map((r) => [r.path, r.content]));
 
-    for (const { filePath, chunks: fileChunks } of sortedFiles) {
-      // 从批量结果中获取文件内容
-      const content = contentMap.get(filePath);
-      if (!content) continue;
+      for (const { filePath, chunks: fileChunks } of sortedFiles) {
+        // 从批量结果中获取文件内容
+        const content = contentMap.get(filePath);
+        if (!content) continue;
 
-      // 合并区间
-      const segments = this.mergeAndSlice(fileChunks, content);
+        // 合并区间
+        const segments = this.mergeAndSlice(fileChunks, content);
 
-      // 每文件最多 N 段
-      const topSegments = segments
-        .sort((a, b) => b.score - a.score)
-        .slice(0, this.config.maxSegmentsPerFile)
-        .sort((a, b) => a.rawStart - b.rawStart); // 按位置排序输出
+        // 每文件最多 N 段
+        const topSegments = segments
+          .sort((a, b) => b.score - a.score)
+          .slice(0, this.config.maxSegmentsPerFile)
+          .sort((a, b) => a.rawStart - b.rawStart); // 按位置排序输出
 
-      // 预算检查
-      const budgetedSegments: Segment[] = [];
-      for (const seg of topSegments) {
-        if (totalChars + seg.text.length > this.config.maxTotalChars) {
-          // 预算用尽，停止添加
-          break;
+        // 预算检查
+        const budgetedSegments: Segment[] = [];
+        for (const seg of topSegments) {
+          if (totalChars + seg.text.length > this.config.maxTotalChars) {
+            // 预算用尽，停止添加
+            break;
+          }
+          totalChars += seg.text.length;
+          budgetedSegments.push(seg);
         }
-        totalChars += seg.text.length;
-        budgetedSegments.push(seg);
+
+        if (budgetedSegments.length > 0) {
+          result.push({ filePath, segments: budgetedSegments });
+        }
+
+        // 预算用尽
+        if (totalChars >= this.config.maxTotalChars) break;
       }
 
-      if (budgetedSegments.length > 0) {
-        result.push({ filePath, segments: budgetedSegments });
-      }
-
-      // 预算用尽
-      if (totalChars >= this.config.maxTotalChars) break;
+      return result;
+    } finally {
+      closeDb(db);
     }
-
-    return result;
   }
 
   /**

--- a/src/search/GraphExpander.ts
+++ b/src/search/GraphExpander.ts
@@ -9,7 +9,7 @@
 
 import type Database from 'better-sqlite3';
 import { getEmbeddingConfig } from '../config.js';
-import { initDb } from '../db/index.js';
+import { closeDb, initDb } from '../db/index.js';
 import { logger } from '../utils/logger.js';
 import { type ChunkRecord, getVectorStore, type VectorStore } from '../vectorStore/index.js';
 import { createResolvers, type ImportResolver } from './resolvers/index.js';
@@ -55,6 +55,15 @@ export class GraphExpander {
     const embeddingConfig = getEmbeddingConfig();
     this.vectorStore = await getVectorStore(this.projectId, embeddingConfig.dimensions);
     this.db = initDb(this.projectId);
+  }
+
+  close(): void {
+    if (this.db) {
+      closeDb(this.db);
+      this.db = null;
+    }
+    this.allFilePaths = null;
+    this.vectorStore = null;
   }
 
   /**
@@ -521,20 +530,11 @@ export class GraphExpander {
 // 工厂函数
 // ===========================================
 
-const expanders = new Map<string, GraphExpander>();
-
-/**
- * 获取或创建 GraphExpander 实例
- */
 export async function getGraphExpander(
   projectId: string,
   config: SearchConfig,
 ): Promise<GraphExpander> {
-  let expander = expanders.get(projectId);
-  if (!expander) {
-    expander = new GraphExpander(projectId, config);
-    await expander.init();
-    expanders.set(projectId, expander);
-  }
+  const expander = new GraphExpander(projectId, config);
+  await expander.init();
   return expander;
 }

--- a/src/search/SearchService.ts
+++ b/src/search/SearchService.ts
@@ -11,7 +11,7 @@
 import type Database from 'better-sqlite3';
 import { getRerankerClient } from '../api/reranker.js';
 import { getEmbeddingConfig } from '../config.js';
-import { initDb } from '../db/index.js';
+import { closeDb, initDb } from '../db/index.js';
 import { getIndexer, type Indexer } from '../indexer/index.js';
 import { isDebugEnabled, logger } from '../utils/logger.js';
 import type { SearchResult as VectorSearchResult } from '../vectorStore/index.js';
@@ -67,6 +67,15 @@ export class SearchService {
     this.indexer = await getIndexer(this.projectId, embeddingConfig.dimensions);
     this.vectorStore = await getVectorStore(this.projectId, embeddingConfig.dimensions);
     this.db = initDb(this.projectId);
+  }
+
+  close(): void {
+    if (this.db) {
+      closeDb(this.db);
+      this.db = null;
+    }
+    this.indexer = null;
+    this.vectorStore = null;
   }
 
   // 公开接口
@@ -669,11 +678,15 @@ export class SearchService {
     if (seeds.length === 0) return [];
 
     const expander = await getGraphExpander(this.projectId, this.config);
-    const { chunks, stats } = await expander.expand(seeds, queryTokens);
+    try {
+      const { chunks, stats } = await expander.expand(seeds, queryTokens);
 
-    logger.debug(stats, '上下文扩展统计');
+      logger.debug(stats, '上下文扩展统计');
 
-    return chunks;
+      return chunks;
+    } finally {
+      expander.close();
+    }
   }
 
   // 工具方法

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -10,25 +10,15 @@ import path from 'node:path';
 import { logger } from './logger.js';
 
 const BASE_DIR = path.join(os.homedir(), '.contextweaver');
+const LOCK_TIMEOUT_MS = 5 * 60 * 1000; // 锁最大持有时长
 const LOCK_CHECK_INTERVAL_MS = 100; // 检查间隔
-const LOCK_WRITE_GRACE_MS = 2000; // 锁文件写入宽限期，避免误删刚创建的锁
+const LOCK_HEARTBEAT_INTERVAL_MS = 5 * 1000; // 心跳刷新间隔
 
 interface LockInfo {
   pid: number;
   timestamp: number;
   operation: string;
-}
-
-/**
- * 获取锁文件年龄（毫秒）
- */
-function getLockAgeMs(lockPath: string): number | null {
-  try {
-    const stats = fs.statSync(lockPath);
-    return Date.now() - stats.mtimeMs;
-  } catch {
-    return null;
-  }
+  token: string;
 }
 
 /**
@@ -39,44 +29,180 @@ function getLockFilePath(projectId: string): string {
 }
 
 /**
- * 检查锁是否有效
- *
- * 锁无效的情况：
- * 1. 锁文件不存在
- * 2. 持有锁的进程已死亡
+ * 判断项目当前是否处于锁定状态
  */
-function isLockValid(lockPath: string): boolean {
+export function isProjectLocked(projectId: string): boolean {
+  return isLockValid(getLockFilePath(projectId));
+}
+
+/**
+ * 读取锁文件内容
+ */
+function readLockInfo(lockPath: string): LockInfo | null {
   try {
     if (!fs.existsSync(lockPath)) {
-      return false;
+      return null;
     }
 
     const content = fs.readFileSync(lockPath, 'utf-8');
-    const lockInfo: LockInfo = JSON.parse(content);
-
-    // 检查进程是否存活（跨平台）
-    try {
-      process.kill(lockInfo.pid, 0); // 发送信号 0 只检查进程是否存在
-      return true;
-    } catch (err) {
-      const error = err as NodeJS.ErrnoException;
-      if (error.code === 'EPERM') {
-        // 没权限发信号但进程存在，视为锁仍有效
-        return true;
-      }
-      logger.warn({ pid: lockInfo.pid }, '持有锁的进程已死亡');
-      return false;
-    }
+    return JSON.parse(content) as LockInfo;
   } catch (err) {
-    const ageMs = getLockAgeMs(lockPath);
-    if (ageMs !== null && ageMs <= LOCK_WRITE_GRACE_MS) {
-      // 刚创建的锁可能尚未写完，短暂视为有效，避免竞态误删
-      return true;
-    }
     const error = err as { message?: string };
     logger.debug({ error: error.message }, '读取锁文件失败');
+    return null;
+  }
+}
+
+/**
+ * 比较两份锁信息是否指向同一个持有者
+ */
+function lockInfoMatches(left: LockInfo | null, right: LockInfo | null): boolean {
+  if (!left || !right) {
     return false;
   }
+  return (
+    left.pid === right.pid &&
+    left.timestamp === right.timestamp &&
+    left.operation === right.operation &&
+    left.token === right.token
+  );
+}
+
+/**
+ * 判断锁信息是否仍然有效
+ */
+function isLockInfoActive(lockInfo: LockInfo, lockPath: string): boolean {
+  if (Date.now() - lockInfo.timestamp > LOCK_TIMEOUT_MS) {
+    logger.warn({ lockInfo, lockPath }, '锁已超时');
+    return false;
+  }
+
+  try {
+    process.kill(lockInfo.pid, 0);
+    return true;
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === 'EPERM') {
+      return true;
+    }
+    logger.warn({ pid: lockInfo.pid }, '持有锁的进程已死亡');
+    return false;
+  }
+}
+
+/**
+ * 检查锁是否有效
+ */
+function isLockValid(lockPath: string): boolean {
+  const lockInfo = readLockInfo(lockPath);
+  if (!lockInfo) {
+    return false;
+  }
+  return isLockInfoActive(lockInfo, lockPath);
+}
+
+/**
+ * 构建锁元数据
+ */
+function buildLockInfo(operation: string, token: string): LockInfo {
+  return {
+    pid: process.pid,
+    timestamp: Date.now(),
+    operation,
+    token,
+  };
+}
+
+/**
+ * 删除锁文件
+ */
+function removeLockFile(lockPath: string): void {
+  try {
+    if (fs.existsSync(lockPath)) {
+      fs.unlinkSync(lockPath);
+    }
+  } catch (err) {
+    const error = err as { message?: string };
+    logger.debug({ error: error.message }, '删除锁文件失败');
+  }
+}
+
+/**
+ * 获取临时锁文件路径
+ */
+function getLockTempFilePath(lockPath: string, token: string): string {
+  return `${lockPath}.${token}.tmp`;
+}
+
+/**
+ * 使用临时文件原子创建锁，避免其他进程读到半写入内容
+ */
+function createLockFile(lockPath: string, operation: string, token: string): boolean {
+  const tempPath = getLockTempFilePath(lockPath, token);
+
+  try {
+    fs.writeFileSync(tempPath, JSON.stringify(buildLockInfo(operation, token)), { flag: 'w' });
+    fs.linkSync(tempPath, lockPath);
+    return true;
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code !== 'EEXIST') {
+      logger.debug({ error: error.message }, '原子创建锁失败');
+    }
+    return false;
+  } finally {
+    try {
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath);
+      }
+    } catch {
+      // 忽略临时文件清理失败
+    }
+  }
+}
+
+/**
+ * 原子刷新锁内容，避免其他进程读到半写入状态
+ */
+function refreshLockFile(lockPath: string, operation: string, token: string): void {
+  const tempPath = getLockTempFilePath(lockPath, `${token}.heartbeat`);
+
+  try {
+    fs.writeFileSync(tempPath, JSON.stringify(buildLockInfo(operation, token)), { flag: 'w' });
+    fs.renameSync(tempPath, lockPath);
+  } catch (err) {
+    try {
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath);
+      }
+    } catch {
+      // 忽略临时文件清理失败
+    }
+    throw err;
+  }
+}
+
+/**
+ * 启动锁心跳
+ */
+function startLockHeartbeat(projectId: string, operation: string, token: string): () => void {
+  const lockPath = getLockFilePath(projectId);
+  const timer = setInterval(() => {
+    const lockInfo = readLockInfo(lockPath);
+    if (!lockInfo || lockInfo.pid !== process.pid || lockInfo.token !== token) {
+      return;
+    }
+
+    try {
+      refreshLockFile(lockPath, operation, token);
+    } catch (err) {
+      const error = err as { message?: string };
+      logger.debug({ error: error.message }, '刷新锁心跳失败');
+    }
+  }, LOCK_HEARTBEAT_INTERVAL_MS);
+
+  timer.unref?.();
+  return () => clearInterval(timer);
 }
 
 /**
@@ -85,67 +211,52 @@ function isLockValid(lockPath: string): boolean {
  * @param projectId 项目 ID
  * @param operation 操作描述（用于日志）
  * @param timeoutMs 等待超时时间，默认 30 秒
- * @returns 是否成功获取锁
+ * @returns 锁句柄，失败时返回 null
  */
 async function acquireLock(
   projectId: string,
   operation: string,
   timeoutMs: number = 30000,
-): Promise<boolean> {
+): Promise<{ token: string } | null> {
   const lockPath = getLockFilePath(projectId);
   const dir = path.dirname(lockPath);
 
-  // 确保目录存在
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
 
   const startTime = Date.now();
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
   while (Date.now() - startTime < timeoutMs) {
-    // 先尝试原子创建锁
-    try {
-      const lockInfo: LockInfo = {
-        pid: process.pid,
-        timestamp: Date.now(),
-        operation,
-      };
+    const existingLockInfo = readLockInfo(lockPath);
 
-      // 使用 wx：文件已存在则抛 EEXIST，避免锁被覆盖
-      fs.writeFileSync(lockPath, JSON.stringify(lockInfo), { flag: 'wx' });
-      logger.debug({ projectId: projectId.slice(0, 10), operation }, '获取锁成功');
-      return true;
-    } catch (err) {
-      const error = err as NodeJS.ErrnoException;
-
-      // 锁已存在：检查是否为失效锁，若失效则移除后重试
-      if (error.code === 'EEXIST') {
-        if (!isLockValid(lockPath)) {
-          try {
-            fs.unlinkSync(lockPath);
-            logger.warn({ projectId: projectId.slice(0, 10) }, '移除失效锁');
-            continue;
-          } catch (unlinkErr) {
-            const unlinkError = unlinkErr as NodeJS.ErrnoException;
-            // 可能是并发下其他进程已删除，忽略
-            if (unlinkError.code !== 'ENOENT') {
-              logger.debug({ error: unlinkError.message }, '移除失效锁失败，重试中...');
-            }
-          }
-        } else {
-          logger.debug({ projectId: projectId.slice(0, 10) }, '等待锁释放...');
-        }
-      } else {
-        logger.debug({ error: error.message }, '获取锁失败，重试中...');
+    if (!existingLockInfo) {
+      if (fs.existsSync(lockPath)) {
+        removeLockFile(lockPath);
       }
+
+      if (createLockFile(lockPath, operation, token)) {
+        const verifyInfo = readLockInfo(lockPath);
+        if (verifyInfo?.pid === process.pid && verifyInfo.token === token) {
+          logger.debug({ projectId: projectId.slice(0, 10), operation }, '获取锁成功');
+          return { token };
+        }
+      }
+    } else if (!isLockInfoActive(existingLockInfo, lockPath)) {
+      const latestLockInfo = readLockInfo(lockPath);
+      if (lockInfoMatches(existingLockInfo, latestLockInfo)) {
+        removeLockFile(lockPath);
+      }
+    } else {
+      logger.debug({ projectId: projectId.slice(0, 10) }, '等待锁释放...');
     }
 
-    // 等待后重试
     await new Promise((resolve) => setTimeout(resolve, LOCK_CHECK_INTERVAL_MS));
   }
 
   logger.warn({ projectId: projectId.slice(0, 10), timeoutMs }, '获取锁超时');
-  return false;
+  return null;
 }
 
 /**
@@ -153,7 +264,7 @@ async function acquireLock(
  *
  * @param projectId 项目 ID
  */
-function releaseLock(projectId: string): void {
+function releaseLock(projectId: string, token: string): void {
   const lockPath = getLockFilePath(projectId);
 
   try {
@@ -165,11 +276,19 @@ function releaseLock(projectId: string): void {
     const content = fs.readFileSync(lockPath, 'utf-8');
     const lockInfo: LockInfo = JSON.parse(content);
 
-    if (lockInfo.pid === process.pid) {
+    if (lockInfo.pid === process.pid && lockInfo.token === token) {
       fs.unlinkSync(lockPath);
       logger.debug({ projectId: projectId.slice(0, 10) }, '释放锁成功');
     } else {
-      logger.warn({ ownPid: process.pid, lockPid: lockInfo.pid }, '尝试释放非自己持有的锁');
+      logger.warn(
+        {
+          ownPid: process.pid,
+          ownToken: token,
+          lockPid: lockInfo.pid,
+          lockToken: lockInfo.token,
+        },
+        '尝试释放非自己持有的锁',
+      );
     }
   } catch (err) {
     const error = err as { message?: string };
@@ -194,15 +313,18 @@ export async function withLock<T>(
   fn: () => Promise<T>,
   timeoutMs: number = 30000,
 ): Promise<T> {
-  const acquired = await acquireLock(projectId, operation, timeoutMs);
+  const lockHandle = await acquireLock(projectId, operation, timeoutMs);
 
-  if (!acquired) {
+  if (!lockHandle) {
     throw new Error(`无法获取项目锁 (${projectId.slice(0, 10)})，其他进程正在操作索引`);
   }
+
+  const stopHeartbeat = startLockHeartbeat(projectId, operation, lockHandle.token);
 
   try {
     return await fn();
   } finally {
-    releaseLock(projectId);
+    stopHeartbeat();
+    releaseLock(projectId, lockHandle.token);
   }
 }


### PR DESCRIPTION
  ## 变更摘要

  这个 PR 主要解决两个问题：

  1. `codebase-retrieval` 在已有索引仓库上仍然同步触发增量索引，导致查询容易超时
  2. 检索链路中的 SQLite 句柄没有及时释放，容易表现为索引库被长期占用、看起来像“进程锁残留”

  ## 主要修改

  ### 1. 调整 `codebase-retrieval` 的索引策略

  - 对首次使用、尚未建立索引的仓库，仍然保持同步建索引
  - 对已经存在索引的仓库，查询优先直接使用现有索引返回结果
  - 增量索引改为后台异步执行，避免把索引耗时绑定到查询主链路上
  - 增加跨进程的后台索引请求标记，减少多个 MCP 进程重复拉起后台索引任务

  ### 2. 强化项目锁实现

  - 为锁增加 owner token，避免不同进程误释放彼此的锁
  - 为长时间索引任务增加心跳续期，避免锁在索引过程中被误判为失效
  - 损坏锁文件和死进程锁可以自动回收
  - 后台 `index` 在短超时下抢不到锁时会快速退出，不再长时间阻塞

  ### 3. 修复检索链路的资源释放问题

  - `SearchService` 增加显式 `close()`
  - `ContextPacker` 在打包完成后关闭 SQLite 连接
  - `GraphExpander` 增加 `close()`，并改为每次请求创建独立实例
  - `handleCodebaseRetrieval()` 在 `finally` 中统一释放检索阶段资源

  ## 行为变化

  - 对“已有索引”的仓库，查询结果会优先基于当前索引返回
  - 如果仓库刚发生变更，极短时间窗口内结果可能略旧，随后由后台增量索引收敛
  - 这个取舍是为了避免查询请求被索引过程阻塞，优先解决超时问题

  ## 验证

  已完成以下验证：

  - `pnpm build` 通过
  - 已建索引仓库上的 `search` 请求可以快速返回，不再被同步增量索引阻塞
  - `handleCodebaseRetrieval()` 执行完成后，不再残留 `index.db` / `index.db-wal` / `index.db-shm` 句柄
  - 损坏锁文件可以自动回收
  - 锁心跳会刷新时间戳，并在任务结束后正确释放锁文件
  - 第二个进程竞争同一把锁时，会在短超时内失败
  - 持有项目锁时，后台 `index` 子进程会快速退出，不会并发写同一个索引库

  ## 风险说明

  - 这是一次有意的行为调整：查询优先级高于增量索引实时性
  - 当前仓库没有现成的自动化测试用例，这次主要依赖源码编译和实际进程级验证