### PR TITLE
fix(cli): normalize numeric technical terms

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ cli
         process.exit(1);
       }
 
-      const technicalTerms = (options.technicalTerms || '')
+      const technicalTerms = String(options.technicalTerms ?? '')
         .split(',')
         .map((t) => t.trim())
         .filter(Boolean);


### PR DESCRIPTION
## Problem

`cw search` currently assumes `options.technicalTerms` is always a string:

```ts
const technicalTerms = (options.technicalTerms || '')
  .split(',')
```

However, the CLI uses `cac`, and `cac` auto-casts numeric-looking option values to JavaScript numbers. Passing a year or other numeric token as `--technical-terms` therefore crashes before retrieval starts.

## Repro

On current `main`, this crashes:

```bash
node dist/index.js search \
  --repo-path . \
  --information-request example \
  --technical-terms 2026
```

Observed error:

```text
TypeError: (options.technicalTerms || "").split is not a function
  at .../dist/index.js:143:59
  at CAC.runMatchedCommand (.../node_modules/cac/dist/index.mjs:610:34)
  at CAC.parse (.../node_modules/cac/dist/index.mjs:537:12)
```

I also verified the underlying parser behavior directly:

```text
2026       => 2026 number
0          => 0 number
001        => 1 number
2026,react => 2026,react string
react      => react string
```

So the bug is not downstream-specific: a direct CLI invocation with a numeric technical term can trigger it.

## Fix

Normalize the CLI option at the CLI boundary before splitting:

```ts
const technicalTerms = String(options.technicalTerms ?? '')
  .split(',')
  .map((t) => t.trim())
  .filter(Boolean);
```

This keeps existing string behavior unchanged while making numeric values safe:

- `2026` becomes `'2026'`
- `undefined` / `null` become `''`
- comma-separated strings continue to work as before

## Validation

- `pnpm build` succeeds.
- After the fix, this no longer throws the `.split is not a function` error:

```bash
node dist/index.js search --repo-path . --information-request test --technical-terms 2026
```

The command reaches retrieval with normalized terms:

```text
MCP codebase-retrieval 调用开始 {"technical_terms":["2026"]}
```

Mixed values also normalize correctly:

```bash
node dist/index.js search --repo-path . --information-request test --technical-terms 2026,react
```

```text
MCP codebase-retrieval 调用开始 {"technical_terms":["2026","react"]}
```

In my local environment the retrieval later hit an unrelated embedding API batch-size error during indexing, but the CLI parsing crash covered by this PR is fixed and the command proceeds past the previous failure point.

## Scope

This PR intentionally keeps the change minimal and only fixes the reported `--technical-terms` crash. Other string-like CLI options may deserve a separate audit because they are parsed by the same `cac` layer, but they are outside this small fix.