### PR TITLE
Feat/voyage embeddingfeat: 支持 Voyage Embedding 并增强 technical_terms 精确召回

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ contextweaver mcp             # 启动 MCP 服务端
 
 ```
 索引: Crawler → Processor → SemanticSplitter → Indexer → VectorStore/SQLite
-搜索: Query → Vector+FTS Recall → RRF Fusion → Rerank → GraphExpander → ContextPacker
+搜索: Query → Vector+FTS+Exact Recall → RRF Fusion → Rerank → GraphExpander → ContextPacker
 ```
 
 ### Key Modules
@@ -44,8 +44,11 @@ contextweaver mcp             # 启动 MCP 服务端
 | **ContextPacker** | `src/search/ContextPacker.ts` | 段落合并和 Token 预算控制 |
 | **SemanticSplitter** | `src/chunking/SemanticSplitter.ts` | AST 语义分片器 (Tree-sitter) |
 | **VectorStore** | `src/vectorStore/index.ts` | LanceDB 适配层 |
-| **Database** | `src/db/index.ts` | SQLite + FTS5 元数据和全文索引 |
+| **Database** | `src/db/index.ts` | SQLite + FTS5 元数据和全文索引；另维护按 `project_id` 隔离的 exact substring index |
 | **MCP Server** | `src/mcp/server.ts` | Model Context Protocol 服务端实现 |
+
+
+Note: `technical_terms` 会触发 fixed-string exact retrieval，用于匹配包含 `@`、`.`、`()` 等符号的完整术语。
 
 ### Import Resolvers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ contextweaver mcp             # 启动 MCP 服务端
 
 ```
 索引: Crawler → Processor → SemanticSplitter → Indexer → VectorStore/SQLite
-搜索: Query → Vector+FTS Recall → RRF Fusion → Rerank → GraphExpander → ContextPacker
+搜索: Query → Vector+FTS+Exact Recall → RRF Fusion → Rerank → GraphExpander → ContextPacker
 ```
 
 ### Key Modules
@@ -44,8 +44,11 @@ contextweaver mcp             # 启动 MCP 服务端
 | **ContextPacker** | `src/search/ContextPacker.ts` | 段落合并和 Token 预算控制 |
 | **SemanticSplitter** | `src/chunking/SemanticSplitter.ts` | AST 语义分片器 (Tree-sitter) |
 | **VectorStore** | `src/vectorStore/index.ts` | LanceDB 适配层 |
-| **Database** | `src/db/index.ts` | SQLite + FTS5 元数据和全文索引 |
+| **Database** | `src/db/index.ts` | SQLite + FTS5 元数据和全文索引；另维护按 `project_id` 隔离的 exact substring index |
 | **MCP Server** | `src/mcp/server.ts` | Model Context Protocol 服务端实现 |
+
+
+Note: `technical_terms` 会触发 fixed-string exact retrieval，用于匹配包含 `@`、`.`、`()` 等符号的完整术语。
 
 ### Import Resolvers
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ EMBEDDINGS_MODEL=BAAI/bge-m3
 EMBEDDINGS_MAX_CONCURRENCY=10
 EMBEDDINGS_DIMENSIONS=1024
 
+# Voyage 兼容配置（可选）
+# EMBEDDINGS_PROVIDER=voyage
+# EMBEDDINGS_BASE_URL=https://api.voyageai.com/v1/embeddings
+# EMBEDDINGS_MODEL=voyage-code-3
+# EMBEDDINGS_OUTPUT_DIMENSION=1024
+# EMBEDDINGS_TRUNCATION=true
+
 # Reranker 配置（必需）
 RERANK_API_KEY=your-api-key-here
 RERANK_BASE_URL=https://api.siliconflow.cn/v1/rerank
@@ -263,8 +270,11 @@ contextweaver/
 | `EMBEDDINGS_API_KEY` | ✅ | - | Embedding API 密钥 |
 | `EMBEDDINGS_BASE_URL` | ✅ | - | Embedding API 地址 |
 | `EMBEDDINGS_MODEL` | ✅ | - | Embedding 模型名称 |
+| `EMBEDDINGS_PROVIDER` | ❌ | auto | `voyage` 或 `openai-compatible`，未设置时根据 URL 自动识别 Voyage |
 | `EMBEDDINGS_MAX_CONCURRENCY` | ❌ | 10 | Embedding 并发数 |
 | `EMBEDDINGS_DIMENSIONS` | ❌ | 1024 | 向量维度 |
+| `EMBEDDINGS_OUTPUT_DIMENSION` | ❌ | - | Voyage 输出向量维度，应与 `EMBEDDINGS_DIMENSIONS` 保持一致 |
+| `EMBEDDINGS_TRUNCATION` | ❌ | - | Voyage 是否截断超长输入 |
 | `RERANK_API_KEY` | ✅ | - | Reranker API 密钥 |
 | `RERANK_BASE_URL` | ✅ | - | Reranker API 地址 |
 | `RERANK_MODEL` | ✅ | - | Reranker 模型名称 |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ npm install -g @hsingjui/contextweaver
 pnpm add -g @hsingjui/contextweaver
 ```
 
+> 如果你从源码修改 ContextWeaver，请注意全局安装的 `contextweaver` 命令可能仍指向 npm 包版本；本地源码改动需要重新 build/link/install 后才会影响全局 CLI。
+
+
 ### 初始化配置
 
 ```bash
@@ -98,6 +101,25 @@ RERANK_TOP_N=20
 # IGNORE_PATTERNS=.venv,node_modules
 ```
 
+#### Voyage Embeddings 说明
+
+- 使用 Voyage provider 时可设置 `EMBEDDINGS_PROVIDER=voyage`，并将 `EMBEDDINGS_BASE_URL` 设为 `https://api.voyageai.com/v1/embeddings`。
+- `EMBEDDINGS_MODEL` 可按需配置，`voyage-code-3` 只是示例模型名。
+- `EMBEDDINGS_DIMENSIONS` 表示本地向量库维度，必须与最终返回向量维度一致。
+- `EMBEDDINGS_OUTPUT_DIMENSION` 是 Voyage API 的可选输出维度；不配置时使用 Voyage 模型默认维度。
+- `EMBEDDINGS_OUTPUT_DTYPE` 是 Voyage API 的可选输出类型，默认 `float`。
+- Voyage 索引时使用 `input_type=document`，查询时使用 `input_type=query`。
+- OpenAI-compatible / SiliconFlow provider 使用 `encoding_format=float`。
+
+#### IGNORE_PATTERNS 说明
+
+```bash
+IGNORE_PATTERNS=node_modules,dist,build,target,.git,.venv
+```
+
+建议忽略生成物、缓存目录和大型二进制目录，避免索引无关内容并提升性能。注意 junction、symlink 或 workspace 挂载目录不一定都会被扫描；如遇缺失，请改用实际源码目录，或将 workspace 复制到普通目录后再索引。
+
+
 ### 索引代码库
 
 ```bash
@@ -111,6 +133,9 @@ contextweaver index /path/to/your/project
 contextweaver index --force
 ```
 
+> 更换 Embedding provider、模型、输出维度或 `EMBEDDINGS_OUTPUT_DTYPE` 后，旧向量索引不再兼容，请执行 `contextweaver index --force` 重建索引。`--force` 也会清理当前 project 的 exact index；exact index 按 `project_id` 隔离，用于 `technical_terms` fixed-string 精确召回。
+
+
 ### 本地搜索
 
 ```bash
@@ -120,6 +145,22 @@ cw search --information-request "用户认证流程是如何实现的？"
 # 带精确术语
 cw search --information-request "数据库连接逻辑" --technical-terms "DatabasePool,Connection"
 ```
+
+#### technical_terms 精确召回
+
+`technical_terms` 不只是拼接到语义 query 中，还会额外触发 fixed-string exact retrieval，用于召回包含完整技术术语的代码片段：
+
+- 支持 `@ControllerAdvice`、`R.failed`、`useQuery()` 等包含符号的完整术语。
+- 不依赖 FTS tokenizer，不使用 regex，也不会拆分 term。
+- `missingExactTechnicalTerms` 表示本次 exact retrieval 未在候选中命中的术语，便于判断是否需要换词或扩大检索范围。
+- exact retrieval 设有 cap，用于限制候选数量和扫描成本，避免在大仓库中造成性能问题。
+
+PowerShell 中 `technical_terms` 可使用逗号分隔：
+
+```powershell
+contextweaver search --information-request "错误处理逻辑" --technical-terms "R.failed,e.getMessage,catch"
+```
+
 
 ### 启动 MCP 服务器
 
@@ -156,6 +197,25 @@ ContextWeaver 提供一个核心 MCP 工具：`codebase-retrieval`
 | `repo_path` | string | ✅ | 代码库根目录的绝对路径 |
 | `information_request` | string | ✅ | 自然语言形式的语义意图描述 |
 | `technical_terms` | string[] | ❌ | 精确技术术语（类名、函数名等） |
+
+#### MCP technical_terms 示例
+
+MCP 调用时 `technical_terms` 使用 JSON array：
+
+```json
+{
+  "repo_path": "d:/code/your-project",
+  "information_request": "错误处理逻辑",
+  "technical_terms": ["R.failed", "e.getMessage", "catch"]
+}
+```
+
+响应摘要中：
+
+- `Missing exact technical terms`：exact retrieval 未命中的 technical terms。
+- `Exact: seeds=..., candidates=..., scanned=..., elapsed=..., truncated=...`：exact retrieval 的种子数量、候选数量、扫描数量、耗时和是否因 cap 截断。
+- `Skipped exact technical terms`：被跳过的术语，通常是空值、重复值或超出限制的输入。
+
 
 #### 设计理念
 
@@ -210,7 +270,7 @@ flowchart TB
 | **GraphExpander** | 上下文扩展器，执行 E1/E2/E3 三阶段扩展策略 |
 | **ContextPacker** | 上下文打包器，负责段落合并和 Token 预算控制 |
 | **VectorStore** | LanceDB 适配层，管理向量索引的增删改查 |
-| **SQLite (FTS5)** | 元数据存储 + 全文搜索索引 |
+| **SQLite (FTS5 + Exact)** | 元数据存储 + 全文搜索索引；同时使用现有 SQLite / better-sqlite3 维护按 `project_id` 隔离的 exact substring index，用于 `technical_terms` fixed-string 精确召回（无需额外安装数据库） |
 | **SemanticSplitter** | AST 语义分片器，基于 Tree-sitter 解析 |
 
 ## 📁 项目结构

--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ EMBEDDINGS_MODEL=BAAI/bge-m3
 EMBEDDINGS_MAX_CONCURRENCY=10
 EMBEDDINGS_DIMENSIONS=1024
 
-# Voyage 兼容配置（可选）
+# Voyage example:
 # EMBEDDINGS_PROVIDER=voyage
 # EMBEDDINGS_BASE_URL=https://api.voyageai.com/v1/embeddings
 # EMBEDDINGS_MODEL=voyage-code-3
-# EMBEDDINGS_OUTPUT_DIMENSION=1024
-# EMBEDDINGS_TRUNCATION=true
+# EMBEDDINGS_DIMENSIONS=1024
+# EMBEDDINGS_OUTPUT_DIMENSION=1024  # 可选；不配置则使用 Voyage 模型默认维度
+# EMBEDDINGS_OUTPUT_DTYPE=float     # 可选；默认 float
 
 # Reranker 配置（必需）
 RERANK_API_KEY=your-api-key-here
@@ -272,9 +273,9 @@ contextweaver/
 | `EMBEDDINGS_MODEL` | ✅ | - | Embedding 模型名称 |
 | `EMBEDDINGS_PROVIDER` | ❌ | auto | `voyage` 或 `openai-compatible`，未设置时根据 URL 自动识别 Voyage |
 | `EMBEDDINGS_MAX_CONCURRENCY` | ❌ | 10 | Embedding 并发数 |
-| `EMBEDDINGS_DIMENSIONS` | ❌ | 1024 | 向量维度 |
-| `EMBEDDINGS_OUTPUT_DIMENSION` | ❌ | - | Voyage 输出向量维度，应与 `EMBEDDINGS_DIMENSIONS` 保持一致 |
-| `EMBEDDINGS_TRUNCATION` | ❌ | - | Voyage 是否截断超长输入 |
+| `EMBEDDINGS_DIMENSIONS` | ❌ | 1024 | 本地向量库维度，必须与 Embedding API 实际返回维度一致 |
+| `EMBEDDINGS_OUTPUT_DIMENSION` | ❌ | - | Voyage 输出向量维度；不配置则使用 Voyage 模型默认维度，实际返回维度仍必须与 `EMBEDDINGS_DIMENSIONS` 一致 |
+| `EMBEDDINGS_OUTPUT_DTYPE` | ❌ | float | Voyage 输出向量数据类型，可选：`float` / `int8` / `uint8` / `binary` / `ubinary` |
 | `RERANK_API_KEY` | ✅ | - | Reranker API 密钥 |
 | `RERANK_BASE_URL` | ✅ | - | Reranker API 地址 |
 | `RERANK_MODEL` | ✅ | - | Reranker 模型名称 |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+﻿onlyBuiltDependencies:
+  - "@keqingmoe/tree-sitter"
+  - better-sqlite3
+  - esbuild
+  - tree-sitter-c-sharp
+  - tree-sitter-c
+  - tree-sitter-cpp
+  - tree-sitter-go
+  - tree-sitter-java
+  - tree-sitter-javascript
+  - tree-sitter-python
+  - tree-sitter-rust
+  - tree-sitter-typescript

--- a/src/api/embedding.ts
+++ b/src/api/embedding.ts
@@ -21,7 +21,7 @@ interface EmbeddingRequest {
   encoding_format?: 'float' | 'base64';
   input_type?: EmbeddingInputType;
   output_dimension?: number;
-  truncation?: boolean;
+  output_dtype?: 'float' | 'int8' | 'uint8' | 'binary' | 'ubinary';
 }
 
 /** 单个 Embedding 结果 */
@@ -327,7 +327,7 @@ export class EmbeddingClient {
    * 获取单个文本的 Embedding
    */
   async embed(text: string, inputType: EmbeddingInputType = 'query'): Promise<number[]> {
-    const results = await this.embedBatch([text], 20, undefined, inputType);
+    const results = await this.embedBatch([text], 1, undefined, inputType);
     return results[0].embedding;
   }
 
@@ -529,11 +529,10 @@ export class EmbeddingClient {
 
     if (this.config.provider === 'voyage') {
       requestBody.input_type = inputType;
-      if (this.config.outputDimension !== undefined) {
+      requestBody.output_dtype = this.config.outputDtype ?? 'float';
+
+      if (Number.isFinite(this.config.outputDimension)) {
         requestBody.output_dimension = this.config.outputDimension;
-      }
-      if (this.config.truncation !== undefined) {
-        requestBody.truncation = this.config.truncation;
       }
     } else {
       requestBody.encoding_format = 'float';

--- a/src/api/embedding.ts
+++ b/src/api/embedding.ts
@@ -1,7 +1,7 @@
 /**
  * Embedding 客户端
  *
- * 调用 SiliconFlow Embedding API，将文本转换为向量
+ * 调用 Embedding API，将文本转换为向量
  * 支持并发控制、批量处理和智能速率限制
  *
  * 速率限制策略：
@@ -19,6 +19,9 @@ interface EmbeddingRequest {
   model: string;
   input: string | string[];
   encoding_format?: 'float' | 'base64';
+  input_type?: EmbeddingInputType;
+  output_dimension?: number;
+  truncation?: boolean;
 }
 
 /** 单个 Embedding 结果 */
@@ -54,6 +57,8 @@ export interface EmbeddingResult {
   embedding: number[];
   index: number;
 }
+
+export type EmbeddingInputType = 'query' | 'document';
 
 /**
  * 进度追踪器
@@ -321,8 +326,8 @@ export class EmbeddingClient {
   /**
    * 获取单个文本的 Embedding
    */
-  async embed(text: string): Promise<number[]> {
-    const results = await this.embedBatch([text]);
+  async embed(text: string, inputType: EmbeddingInputType = 'query'): Promise<number[]> {
+    const results = await this.embedBatch([text], 20, undefined, inputType);
     return results[0].embedding;
   }
 
@@ -331,11 +336,13 @@ export class EmbeddingClient {
    * @param texts 待处理的文本数组
    * @param batchSize 每批次发送的文本数量（默认 20）
    * @param onProgress 可选的进度回调 (completed, total) => void
+   * @param inputType Voyage 检索任务类型：索引用 document，搜索用 query
    */
   async embedBatch(
     texts: string[],
     batchSize = 20,
     onProgress?: (completed: number, total: number) => void,
+    inputType: EmbeddingInputType = 'document',
   ): Promise<EmbeddingResult[]> {
     if (texts.length === 0) {
       return [];
@@ -353,7 +360,7 @@ export class EmbeddingClient {
     // 使用速率限制控制器处理各批次
     const batchResults = await Promise.all(
       batches.map((batch, batchIndex) =>
-        this.processWithRateLimit(batch, batchIndex * batchSize, progress),
+        this.processWithRateLimit(batch, batchIndex * batchSize, progress, inputType),
       ),
     );
 
@@ -372,6 +379,7 @@ export class EmbeddingClient {
     texts: string[],
     startIndex: number,
     progress: ProgressTracker,
+    inputType: EmbeddingInputType,
   ): Promise<EmbeddingResult[]> {
     const MAX_NETWORK_RETRIES = 3;
     const INITIAL_RETRY_DELAY_MS = 1000;
@@ -383,7 +391,7 @@ export class EmbeddingClient {
       await this.rateLimiter.acquire();
 
       try {
-        const result = await this.processBatch(texts, startIndex, progress);
+        const result = await this.processBatch(texts, startIndex, progress, inputType);
         this.rateLimiter.releaseSuccess();
         return result;
       } catch (err) {
@@ -481,12 +489,9 @@ export class EmbeddingClient {
     texts: string[],
     startIndex: number,
     progress: ProgressTracker,
+    inputType: EmbeddingInputType,
   ): Promise<EmbeddingResult[]> {
-    const requestBody: EmbeddingRequest = {
-      model: this.config.model,
-      input: texts,
-      encoding_format: 'float',
-    };
+    const requestBody = this.buildRequestBody(texts, inputType);
 
     const response = await fetch(this.config.baseUrl, {
       method: 'POST',
@@ -497,7 +502,7 @@ export class EmbeddingClient {
       body: JSON.stringify(requestBody),
     });
 
-    const data = (await response.json()) as EmbeddingResponse & EmbeddingErrorResponse;
+    const data = await this.parseJsonResponse(response);
 
     if (!response.ok || data.error) {
       const errorMsg = data.error?.message || `HTTP ${response.status}`;
@@ -514,6 +519,43 @@ export class EmbeddingClient {
     progress.recordBatch(data.usage?.total_tokens || 0);
 
     return results;
+  }
+
+  private buildRequestBody(texts: string[], inputType: EmbeddingInputType): EmbeddingRequest {
+    const requestBody: EmbeddingRequest = {
+      model: this.config.model,
+      input: texts,
+    };
+
+    if (this.config.provider === 'voyage') {
+      requestBody.input_type = inputType;
+      if (this.config.outputDimension !== undefined) {
+        requestBody.output_dimension = this.config.outputDimension;
+      }
+      if (this.config.truncation !== undefined) {
+        requestBody.truncation = this.config.truncation;
+      }
+    } else {
+      requestBody.encoding_format = 'float';
+    }
+
+    return requestBody;
+  }
+
+  private async parseJsonResponse(
+    response: Response,
+  ): Promise<EmbeddingResponse & EmbeddingErrorResponse> {
+    const bodyText = await response.text();
+    try {
+      return JSON.parse(bodyText) as EmbeddingResponse & EmbeddingErrorResponse;
+    } catch (err) {
+      const preview = bodyText.replace(/\s+/g, ' ').slice(0, 200);
+      throw new Error(
+        `Embedding API 返回非 JSON 响应: HTTP ${response.status}, content-type=${response.headers.get(
+          'content-type',
+        ) || 'unknown'}, body=${preview}`,
+      );
+    }
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,9 @@ loadEnv();
 
 // API 配置类型定义
 
+const EMBEDDING_OUTPUT_DTYPES = ['float', 'int8', 'uint8', 'binary', 'ubinary'] as const;
+type EmbeddingOutputDtype = (typeof EMBEDDING_OUTPUT_DTYPES)[number];
+
 export interface EmbeddingConfig {
   apiKey: string;
   baseUrl: string;
@@ -63,8 +66,8 @@ export interface EmbeddingConfig {
   provider: 'openai-compatible' | 'voyage';
   /** Voyage 可选参数：输出向量维度 */
   outputDimension?: number;
-  /** Voyage 可选参数：是否截断超长输入 */
-  truncation?: boolean;
+  /** Voyage 可选参数：输出向量数据类型 */
+  outputDtype?: EmbeddingOutputDtype;
 }
 
 export interface RerankerConfig {
@@ -159,14 +162,17 @@ export function getEmbeddingConfig(): EmbeddingConfig {
 
   const dimensions = parseInt(process.env.EMBEDDINGS_DIMENSIONS || '1024', 10);
   const outputDimension = parseInt(process.env.EMBEDDINGS_OUTPUT_DIMENSION || '', 10);
+  const rawOutputDtype = process.env.EMBEDDINGS_OUTPUT_DTYPE;
+  if (rawOutputDtype && !EMBEDDING_OUTPUT_DTYPES.includes(rawOutputDtype as EmbeddingOutputDtype)) {
+    throw new Error(
+      `EMBEDDINGS_OUTPUT_DTYPE 仅支持: ${EMBEDDING_OUTPUT_DTYPES.join(', ')}`,
+    );
+  }
+  const outputDtype = rawOutputDtype as EmbeddingOutputDtype | undefined;
   const provider =
-    process.env.EMBEDDINGS_PROVIDER === 'voyage' || baseUrl.includes('voyageai.com')
+    process.env.EMBEDDINGS_PROVIDER === 'voyage' || baseUrl.toLowerCase().includes('voyageai.com')
       ? 'voyage'
       : 'openai-compatible';
-  const truncation =
-    process.env.EMBEDDINGS_TRUNCATION === undefined
-      ? undefined
-      : process.env.EMBEDDINGS_TRUNCATION === 'true';
 
   return {
     apiKey,
@@ -176,7 +182,7 @@ export function getEmbeddingConfig(): EmbeddingConfig {
     dimensions: Number.isNaN(dimensions) ? 1024 : dimensions,
     provider,
     outputDimension: Number.isNaN(outputDimension) ? undefined : outputDimension,
-    truncation,
+    outputDtype,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,12 @@ export interface EmbeddingConfig {
   maxConcurrency: number;
   /** 向量维度 */
   dimensions: number;
+  /** Embedding API 提供方，用于兼容非 OpenAI 格式的请求参数 */
+  provider: 'openai-compatible' | 'voyage';
+  /** Voyage 可选参数：输出向量维度 */
+  outputDimension?: number;
+  /** Voyage 可选参数：是否截断超长输入 */
+  truncation?: boolean;
 }
 
 export interface RerankerConfig {
@@ -152,6 +158,15 @@ export function getEmbeddingConfig(): EmbeddingConfig {
   }
 
   const dimensions = parseInt(process.env.EMBEDDINGS_DIMENSIONS || '1024', 10);
+  const outputDimension = parseInt(process.env.EMBEDDINGS_OUTPUT_DIMENSION || '', 10);
+  const provider =
+    process.env.EMBEDDINGS_PROVIDER === 'voyage' || baseUrl.includes('voyageai.com')
+      ? 'voyage'
+      : 'openai-compatible';
+  const truncation =
+    process.env.EMBEDDINGS_TRUNCATION === undefined
+      ? undefined
+      : process.env.EMBEDDINGS_TRUNCATION === 'true';
 
   return {
     apiKey,
@@ -159,6 +174,9 @@ export function getEmbeddingConfig(): EmbeddingConfig {
     model,
     maxConcurrency: Number.isNaN(maxConcurrency) ? 4 : maxConcurrency,
     dimensions: Number.isNaN(dimensions) ? 1024 : dimensions,
+    provider,
+    outputDimension: Number.isNaN(outputDimension) ? undefined : outputDimension,
+    truncation,
   };
 }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
+import { initExactIndex } from '../search/exactIndex.js';
 import {
   batchDeleteFileFts,
   batchUpsertFileFts,
@@ -123,6 +124,9 @@ export function initDb(projectId: string): Database.Database {
   // 初始化 FTS 表（词法搜索支持）
   initFilesFts(db);
   initChunksFts(db);
+
+  // 初始化 fixed-string exact substring 索引
+  initExactIndex(db);
 
   return db;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,13 @@ EMBEDDINGS_MODEL=BAAI/bge-m3
 EMBEDDINGS_MAX_CONCURRENCY=10
 EMBEDDINGS_DIMENSIONS=1024
 
+# Voyage 兼容配置（可选）
+# EMBEDDINGS_PROVIDER=voyage
+# EMBEDDINGS_BASE_URL=https://api.voyageai.com/v1/embeddings
+# EMBEDDINGS_MODEL=voyage-code-3
+# EMBEDDINGS_OUTPUT_DIMENSION=1024
+# EMBEDDINGS_TRUNCATION=true
+
 # Reranker 配置（必需）
 RERANK_API_KEY=your-api-key-here
 RERANK_BASE_URL=https://api.siliconflow.cn/v1/rerank
@@ -129,10 +136,21 @@ cli
       process.stdout.write('\n');
 
       const duration = ((Date.now() - startTime) / 1000).toFixed(2);
-      logger.info(`索引完成 (${duration}s)`);
+      const vectorIndexFailed = stats.vectorIndex !== undefined && stats.vectorIndex.errors > 0;
+      if (vectorIndexFailed) {
+        logger.warn(`扫描完成，但向量索引失败 (${duration}s)`);
+      } else {
+        logger.info(`索引完成 (${duration}s)`);
+      }
       logger.info(
         `总数:${stats.totalFiles} 新增:${stats.added} 修改:${stats.modified} 未变:${stats.unchanged} 删除:${stats.deleted} 跳过:${stats.skipped} 错误:${stats.errors}`,
       );
+      if (vectorIndexFailed) {
+        logger.warn(
+          `向量索引失败: 成功:${stats.vectorIndex?.indexed ?? 0} 删除:${stats.vectorIndex?.deleted ?? 0} 错误:${stats.vectorIndex?.errors ?? 0}`,
+        );
+        logger.warn(`请修复 Embedding 配置或网络问题后重新创建索引: contextweaver index "${rootPath}" --force`);
+      }
     } catch (err) {
       const error = err as { message?: string; stack?: string };
       logger.error({ err, stack: error.stack }, `索引失败: ${error.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,12 +63,13 @@ EMBEDDINGS_MODEL=BAAI/bge-m3
 EMBEDDINGS_MAX_CONCURRENCY=10
 EMBEDDINGS_DIMENSIONS=1024
 
-# Voyage 兼容配置（可选）
+# Voyage example:
 # EMBEDDINGS_PROVIDER=voyage
 # EMBEDDINGS_BASE_URL=https://api.voyageai.com/v1/embeddings
 # EMBEDDINGS_MODEL=voyage-code-3
-# EMBEDDINGS_OUTPUT_DIMENSION=1024
-# EMBEDDINGS_TRUNCATION=true
+# EMBEDDINGS_DIMENSIONS=1024
+# EMBEDDINGS_OUTPUT_DIMENSION=1024  # 可选；不配置则使用 Voyage 模型默认维度
+# EMBEDDINGS_OUTPUT_DTYPE=float     # 可选；默认 float
 
 # Reranker 配置（必需）
 RERANK_API_KEY=your-api-key-here

--- a/src/indexer/index.test.ts
+++ b/src/indexer/index.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import Database from 'better-sqlite3';
+import type { ProcessedChunk } from '../chunking/types.js';
+import { getFilesNeedingVectorIndex } from '../db/index.js';
+import { initExactIndex, searchExactIndex } from '../search/exactIndex.js';
+import type { ProcessResult } from '../scanner/processor.js';
+import { Indexer } from './index.js';
+
+function initTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE files (
+      path TEXT PRIMARY KEY,
+      hash TEXT NOT NULL,
+      mtime INTEGER NOT NULL,
+      size INTEGER NOT NULL,
+      content TEXT,
+      language TEXT NOT NULL,
+      vector_index_hash TEXT
+    )
+  `);
+  initExactIndex(db);
+  return db;
+}
+
+function makeChunk(filePath: string, content: string): ProcessedChunk {
+  return {
+    displayCode: content,
+    vectorText: content,
+    nwsSize: content.trim().length,
+    metadata: {
+      startIndex: 0,
+      endIndex: content.length,
+      rawSpan: { start: 0, end: content.length },
+      vectorSpan: { start: 0, end: content.length },
+      filePath,
+      language: 'typescript',
+      contextPath: [filePath],
+    },
+  };
+}
+
+function makeResult(path: string, hash: string, content: string): ProcessResult {
+  return {
+    absPath: path,
+    relPath: path,
+    hash,
+    content,
+    chunks: [makeChunk(path, content)],
+    language: 'typescript',
+    mtime: 1,
+    size: content.length,
+    status: 'added',
+  };
+}
+
+describe('Indexer exact index consistency', () => {
+  it('counts exact index write failure as indexing error and does not update vector_index_hash', async () => {
+    const db = initTestDb();
+    try {
+      db.prepare(
+        'INSERT INTO files(path, hash, mtime, size, content, language, vector_index_hash) VALUES (?, ?, ?, ?, ?, ?, NULL)',
+      ).run('src/example.ts', 'hash-1', 1, 18, 'export const ok = 1;', 'typescript');
+      db.exec('DROP TABLE exact_grams');
+
+      const indexer = new Indexer('test-project', 2) as unknown as {
+        embeddingClient: { embedBatch: (...args: unknown[]) => Promise<Array<{ embedding: number[] }>> };
+        vectorStore: { batchUpsertFiles: (...args: unknown[]) => Promise<void> };
+        indexFiles: Indexer['indexFiles'];
+      };
+      indexer.embeddingClient = {
+        embedBatch: async () => [{ embedding: [0.1, 0.2] }],
+      };
+      indexer.vectorStore = {
+        batchUpsertFiles: async () => {},
+      };
+
+      const result = await indexer.indexFiles(db, [
+        makeResult('src/example.ts', 'hash-1', 'export const ok = 1;'),
+      ]);
+
+      assert.equal(result.errors, 1);
+      assert.equal(result.indexed, 0);
+      const row = db.prepare('SELECT vector_index_hash FROM files WHERE path = ?').get('src/example.ts') as {
+        vector_index_hash: string | null;
+      };
+      assert.equal(row.vector_index_hash, null);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('retries exact index write after a previous exact index failure', async () => {
+    const db = initTestDb();
+    try {
+      const projectId = 'test-project';
+      const filePath = 'src/retry-example.ts';
+      const hash = 'hash-retry-1';
+      const technicalTerm = 'retryExactTerm';
+      const content = `export const ${technicalTerm} = true;`;
+
+      db.prepare(
+        'INSERT INTO files(path, hash, mtime, size, content, language, vector_index_hash) VALUES (?, ?, ?, ?, ?, ?, NULL)',
+      ).run(filePath, hash, 1, content.length, content, 'typescript');
+
+      let embedBatchCalls = 0;
+      let vectorUpsertCalls = 0;
+      const indexer = new Indexer(projectId, 2) as unknown as {
+        embeddingClient: { embedBatch: (...args: unknown[]) => Promise<Array<{ embedding: number[] }>> };
+        vectorStore: { batchUpsertFiles: (...args: unknown[]) => Promise<void> };
+        indexFiles: Indexer['indexFiles'];
+      };
+      indexer.embeddingClient = {
+        embedBatch: async () => {
+          embedBatchCalls++;
+          return [{ embedding: [0.1, 0.2] }];
+        },
+      };
+      indexer.vectorStore = {
+        batchUpsertFiles: async () => {
+          vectorUpsertCalls++;
+        },
+      };
+
+      db.exec('DROP TABLE exact_grams');
+
+      const firstResult = await indexer.indexFiles(db, [makeResult(filePath, hash, content)]);
+
+      assert.equal(firstResult.errors, 1);
+      assert.equal(firstResult.indexed, 0);
+      assert.equal(getFilesNeedingVectorIndex(db).includes(filePath), true);
+      const afterFirst = db.prepare('SELECT vector_index_hash FROM files WHERE path = ?').get(filePath) as {
+        vector_index_hash: string | null;
+      };
+      assert.equal(afterFirst.vector_index_hash, null);
+
+      initExactIndex(db);
+
+      const secondResult = await indexer.indexFiles(db, [makeResult(filePath, hash, content)]);
+
+      assert.equal(secondResult.errors, 0);
+      assert.equal(secondResult.indexed, 1);
+      assert.equal(embedBatchCalls, 2);
+      assert.equal(vectorUpsertCalls, 2);
+      assert.equal(getFilesNeedingVectorIndex(db).includes(filePath), false);
+      const afterSecond = db.prepare('SELECT vector_index_hash FROM files WHERE path = ?').get(filePath) as {
+        vector_index_hash: string | null;
+      };
+      assert.equal(afterSecond.vector_index_hash, hash);
+
+      const exactResult = searchExactIndex(db, projectId, [technicalTerm]);
+      assert.equal(exactResult.hits.length, 1);
+      assert.equal(exactResult.hits[0].chunk.file_path, filePath);
+      assert.deepEqual(exactResult.missingExactTechnicalTerms, []);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -14,6 +14,11 @@ import type { ProcessedChunk } from '../chunking/types.js';
 import { batchUpdateVectorIndexHash, clearVectorIndexHash } from '../db/index.js';
 import type { ProcessResult } from '../scanner/processor.js';
 import {
+  batchDeleteExactIndex,
+  batchUpsertExactIndex,
+  type ExactIndexChunkInput,
+} from '../search/exactIndex.js';
+import {
   batchDeleteFileChunksFts,
   batchUpsertChunkFts,
   isChunksFtsInitialized,
@@ -37,6 +42,7 @@ export interface IndexStats {
 interface FileToIndex {
   path: string;
   hash: string;
+  content: string;
   chunks: ProcessedChunk[];
 }
 
@@ -99,6 +105,7 @@ export class Indexer {
             toIndex.push({
               path: result.relPath,
               hash: result.hash,
+              content: result.content ?? '',
               chunks: result.chunks,
             });
           } else {
@@ -231,7 +238,7 @@ export class Indexer {
       breadcrumb: string;
       content: string;
     }> = [];
-    const successFiles: Array<{ path: string; hash: string }> = [];
+    const allExactChunks: ExactIndexChunkInput[] = [];
     const errorFiles: string[] = [];
 
     for (let fileIdx = 0; fileIdx < files.length; fileIdx++) {
@@ -276,10 +283,24 @@ export class Indexer {
             breadcrumb: record.breadcrumb,
             content: `${record.breadcrumb}\n${record.display_code}`,
           });
+
+
+          // 收集 fixed-string exact substring 索引数据（raw content + display content）
+          allExactChunks.push({
+            chunkId: record.chunk_id,
+            filePath: record.file_path,
+            fileHash: record.file_hash,
+            chunkIndex: record.chunk_index,
+            startLine: lineNumberAtOffset(file.content, record.raw_start),
+            endLine: lineNumberAtOffset(file.content, record.raw_end),
+            rawStart: record.raw_start,
+            rawEnd: record.raw_end,
+            content: file.content.slice(record.raw_start, record.raw_end),
+            displayCode: record.display_code,
+          });
         }
 
         filesToUpsert.push({ path: file.path, hash: file.hash, records });
-        successFiles.push({ path: file.path, hash: file.hash });
       } catch (err) {
         const error = err as { message?: string; stack?: string };
         logger.error(
@@ -328,15 +349,41 @@ export class Indexer {
       }
     }
 
-    // ===== 阶段 6: 更新 SQLite 元数据 =====
-    if (successFiles.length > 0) {
-      batchUpdateVectorIndexHash(db, successFiles);
+
+    // ===== 阶段 6: 批量更新 fixed-string exact substring 索引 =====
+    if (allExactChunks.length > 0) {
+      try {
+        const pathsToDelete = filesToUpsert.map((f) => f.path);
+        batchDeleteExactIndex(db, this.projectId, pathsToDelete);
+        batchUpsertExactIndex(db, this.projectId, allExactChunks);
+        logger.info(
+          { files: pathsToDelete.length, chunks: allExactChunks.length },
+          'Exact substring 索引批量更新完成',
+        );
+      } catch (err) {
+        const error = err as { message?: string; stack?: string };
+        logger.error(
+          { error: error.message, stack: error.stack },
+          'Exact substring 索引批量更新失败，本批文件不会标记为已索引',
+        );
+        clearVectorIndexHash(
+          db,
+          filesToUpsert.map((f) => f.path),
+        );
+        return { success: 0, errors: filesToUpsert.length + errorFiles.length };
+      }
+    }
+
+    // ===== 阶段 7: 更新 SQLite 元数据 =====
+    if (filesToUpsert.length > 0) {
+      batchUpdateVectorIndexHash(db, filesToUpsert.map(({ path, hash }) => ({ path, hash })));
     }
 
     // 汇总日志
-    logger.info({ success: successFiles.length, errors: errorFiles.length }, '批量索引完成');
+    logger.info({ success: filesToUpsert.length, errors: errorFiles.length }, '批量索引完成');
 
-    return { success: successFiles.length, errors: errorFiles.length };
+
+    return { success: filesToUpsert.length, errors: errorFiles.length };
   }
 
   /**
@@ -352,6 +399,9 @@ export class Indexer {
     if (isChunksFtsInitialized(db)) {
       batchDeleteFileChunksFts(db, paths);
     }
+
+    // 删除 fixed-string exact substring 索引
+    batchDeleteExactIndex(db, this.projectId, paths);
 
     logger.debug({ count: paths.length }, '删除文件索引');
   }
@@ -405,6 +455,16 @@ const indexers = new Map<string, Indexer>();
 /**
  * 获取或创建 Indexer 实例
  */
+
+
+function lineNumberAtOffset(content: string, offset: number): number {
+  let line = 1;
+  const end = Math.max(0, Math.min(offset, content.length));
+  for (let i = 0; i < end; i++) {
+    if (content.charCodeAt(i) === 10) line++;
+  }
+  return line;
+}
 export async function getIndexer(projectId: string, vectorDim = 1024): Promise<Indexer> {
   let indexer = indexers.get(projectId);
   if (!indexer) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -153,15 +153,17 @@ export class Indexer {
       stats.errors = indexResult.errors;
     }
 
-    logger.info(
-      {
-        indexed: stats.indexed,
-        vectorRecordsDeleted: stats.deleted,
-        errors: stats.errors,
-        skipped: stats.skipped,
-      },
-      '向量索引完成',
-    );
+    const logPayload = {
+      indexed: stats.indexed,
+      vectorRecordsDeleted: stats.deleted,
+      errors: stats.errors,
+      skipped: stats.skipped,
+    };
+    if (stats.errors > 0) {
+      logger.warn(logPayload, '向量索引失败，请重新创建索引');
+    } else {
+      logger.info(logPayload, '向量索引完成');
+    }
 
     return stats;
   }
@@ -208,7 +210,7 @@ export class Indexer {
     let embeddings: number[][];
     try {
       // 传递进度回调给 embedBatch，让它在每个 API 批次完成时报告进度
-      const results = await this.embeddingClient.embedBatch(allTexts, 20, onProgress);
+      const results = await this.embeddingClient.embedBatch(allTexts, 20, onProgress, 'document');
       embeddings = results.map((r) => r.embedding);
     } catch (err) {
       const error = err as { message?: string; stack?: string };
@@ -368,7 +370,7 @@ export class Indexer {
    * 文本搜索（先 embedding 再向量搜索）
    */
   async textSearch(query: string, limit = 10, filter?: string) {
-    const queryVector = await this.embeddingClient.embed(query);
+    const queryVector = await this.embeddingClient.embed(query, 'query');
     return this.search(queryVector, limit, filter);
   }
 

--- a/src/mcp/tools/codebaseRetrieval.ts
+++ b/src/mcp/tools/codebaseRetrieval.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import { generateProjectId } from '../../db/index.js';
 // 注意：SearchService 和 scan 改为延迟导入，避免在 MCP 启动时就加载 native 模块
+import type { ScanStats } from '../../scanner/index.js';
 import type { ContextPack, Segment } from '../../search/types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -77,6 +78,13 @@ EMBEDDINGS_MODEL=BAAI/bge-m3
 EMBEDDINGS_MAX_CONCURRENCY=10
 EMBEDDINGS_DIMENSIONS=1024
 
+# Voyage 兼容配置（可选）
+# EMBEDDINGS_PROVIDER=voyage
+# EMBEDDINGS_BASE_URL=https://api.voyageai.com/v1/embeddings
+# EMBEDDINGS_MODEL=voyage-code-3
+# EMBEDDINGS_OUTPUT_DIMENSION=1024
+# EMBEDDINGS_TRUNCATION=true
+
 # Reranker 配置（必需）
 RERANK_API_KEY=your-api-key-here
 RERANK_BASE_URL=https://api.siliconflow.cn/v1/rerank
@@ -115,12 +123,12 @@ async function ensureIndexed(
   repoPath: string,
   projectId: string,
   onProgress?: (current: number, total?: number, message?: string) => void,
-): Promise<void> {
+): Promise<ScanStats> {
   // 延迟导入锁和 scan 函数（避免 MCP 启动时加载 native 模块）
   const { withLock } = await import('../../utils/lock.js');
   const { scan } = await import('../../scanner/index.js');
 
-  await withLock(projectId, 'index', async () => {
+  return withLock(projectId, 'index', async () => {
     const wasIndexed = isProjectIndexed(projectId);
 
     if (!wasIndexed) {
@@ -150,6 +158,8 @@ async function ensureIndexed(
       },
       '索引完成',
     );
+
+    return stats;
   }, INDEX_LOCK_TIMEOUT_MS);
 }
 
@@ -196,7 +206,17 @@ export async function handleCodebaseRetrieval(
   const projectId = generateProjectId(repo_path);
 
   // 2. 确保代码库已索引（自动初始化 + 增量更新）
-  await ensureIndexed(repo_path, projectId, onProgress);
+  const indexStats = await ensureIndexed(repo_path, projectId, onProgress);
+  if (indexStats.vectorIndex && indexStats.vectorIndex.errors > 0) {
+    logger.warn(
+      {
+        projectId: projectId.slice(0, 10),
+        vectorIndex: indexStats.vectorIndex,
+      },
+      '向量索引失败，返回重建索引提示',
+    );
+    return formatVectorIndexFailedResponse(repo_path, indexStats);
+  }
 
   // 3. 合并查询
   // - information_request 驱动语义向量搜索
@@ -273,6 +293,35 @@ export async function handleCodebaseRetrieval(
 
   // 7. 格式化输出
   return formatMcpResponse(contextPack);
+}
+
+/**
+ * 格式化向量索引失败响应
+ */
+function formatVectorIndexFailedResponse(
+  repoPath: string,
+  stats: ScanStats,
+): { content: Array<{ type: 'text'; text: string }> } {
+  const vectorIndex = stats.vectorIndex;
+  const text = `## 向量索引失败
+
+Embedding 阶段有 ${vectorIndex?.errors ?? 0} 个文件索引失败，本次检索未继续执行。
+
+请修复 Embedding 配置或网络问题后重新创建索引：
+
+\`\`\`bash
+contextweaver index "${repoPath}" --force
+\`\`\`
+`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text,
+      },
+    ],
+  };
 }
 
 // 响应格式化

--- a/src/mcp/tools/codebaseRetrieval.ts
+++ b/src/mcp/tools/codebaseRetrieval.ts
@@ -219,14 +219,15 @@ export async function handleCodebaseRetrieval(
   }
 
   // 3. 合并查询
-  // - information_request 驱动语义向量搜索
-  // - technical_terms 增强词法（FTS）匹配
+  // - 保留既有行为：technical_terms 继续增强 semantic / lexical query
+  // - 同时 technical_terms 也会传入 SearchService 走独立 fixed-string exact 召回
   const query = [information_request, ...(technical_terms || [])].filter(Boolean).join(' ');
 
   logger.info(
     {
       projectId: projectId.slice(0, 10),
       query,
+      technical_terms,
     },
     'MCP 查询构建',
   );
@@ -240,12 +241,21 @@ export async function handleCodebaseRetrieval(
   logger.debug('SearchService 初始化完成');
 
   // 6. 执行搜索
-  const contextPack = await service.buildContextPack(query);
+  const contextPack = await service.buildContextPack(query, technical_terms ?? []);
 
   // 详细日志：seeds 信息
   if (contextPack.seeds.length > 0) {
     logger.info(
       {
+        exactSeedCount: contextPack.debug?.exactSeedCount ?? contextPack.seeds.filter((s) => s.source === 'exact').length,
+        lexicalSeedCount: contextPack.seeds.filter((s) => s.source === 'lexical').length,
+        vectorSeedCount: contextPack.seeds.filter((s) => s.source === 'vector').length,
+        exactCandidateCount: contextPack.debug?.exactCandidateCount,
+        exactScanChunkCount: contextPack.debug?.exactScanChunkCount,
+        exactScanElapsedMs: contextPack.debug?.exactScanElapsedMs,
+        exactHitsTruncated: contextPack.debug?.exactHitsTruncated,
+        missingExactTechnicalTerms: contextPack.missingExactTechnicalTerms,
+        skippedTechnicalTerms: contextPack.debug?.skippedTechnicalTerms,
         seeds: contextPack.seeds.map((s) => ({
           file: s.filePath,
           chunk: s.chunkIndex,
@@ -287,6 +297,13 @@ export async function handleCodebaseRetrieval(
         lines: f.segments.map((s) => `L${s.startLine}-${s.endLine}`),
       })),
       timingMs: contextPack.debug?.timingMs,
+      exactSeedCount: contextPack.debug?.exactSeedCount,
+      exactCandidateCount: contextPack.debug?.exactCandidateCount,
+      exactScanChunkCount: contextPack.debug?.exactScanChunkCount,
+      exactScanElapsedMs: contextPack.debug?.exactScanElapsedMs,
+      exactHitsTruncated: contextPack.debug?.exactHitsTruncated,
+      missingExactTechnicalTerms: contextPack.missingExactTechnicalTerms,
+      skippedTechnicalTerms: contextPack.debug?.skippedTechnicalTerms,
     },
     'MCP codebase-retrieval 完成',
   );
@@ -340,12 +357,57 @@ function formatMcpResponse(pack: ContextPack): { content: Array<{ type: 'text'; 
     })
     .join('\n\n---\n\n');
 
+  const missingTermsLine =
+    pack.missingExactTechnicalTerms && pack.missingExactTechnicalTerms.length > 0
+      ? `Missing exact technical terms: ${pack.missingExactTechnicalTerms.join(', ')}`
+      : undefined;
+
+  const exactDebug = pack.debug;
+  const skippedTerms = exactDebug?.skippedTechnicalTerms ?? [];
+  const hasExactDebug =
+    exactDebug !== undefined &&
+    ((exactDebug.exactSeedCount ?? 0) > 0 ||
+      (exactDebug.exactCandidateCount ?? 0) > 0 ||
+      (exactDebug.exactScanChunkCount ?? 0) > 0 ||
+      exactDebug.exactHitsTruncated === true ||
+      (pack.missingExactTechnicalTerms?.length ?? 0) > 0 ||
+      skippedTerms.length > 0);
+  const exactSummaryItems =
+    exactDebug && hasExactDebug
+      ? [
+          typeof exactDebug.exactSeedCount === 'number'
+            ? `seeds=${exactDebug.exactSeedCount}`
+            : undefined,
+          typeof exactDebug.exactCandidateCount === 'number'
+            ? `candidates=${exactDebug.exactCandidateCount}`
+            : undefined,
+          typeof exactDebug.exactScanChunkCount === 'number'
+            ? `scanned=${exactDebug.exactScanChunkCount}`
+            : undefined,
+          typeof exactDebug.exactScanElapsedMs === 'number'
+            ? `elapsed=${exactDebug.exactScanElapsedMs}ms`
+            : undefined,
+          typeof exactDebug.exactHitsTruncated === 'boolean'
+            ? `truncated=${exactDebug.exactHitsTruncated}`
+            : undefined,
+        ].filter(Boolean)
+      : [];
+  const exactSummaryLine =
+    exactSummaryItems.length > 0 ? `Exact: ${exactSummaryItems.join(', ')}` : undefined;
+  const skippedTermsLine =
+    skippedTerms.length > 0 ? `Skipped exact technical terms: ${skippedTerms.join(', ')}` : undefined;
+
   // 构建摘要
   const summary = [
     `Found ${seeds.length} relevant code blocks`,
     `Files: ${files.length}`,
     `Total segments: ${files.reduce((acc, f) => acc + f.segments.length, 0)}`,
-  ].join(' | ');
+    missingTermsLine,
+    exactSummaryLine,
+    skippedTermsLine,
+  ]
+    .filter(Boolean)
+    .join(' | ');
 
   const text = `${summary}\n\n${fileBlocks}`;
 

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -261,17 +261,47 @@ export async function scan(rootPath: string, options: ScanOptions = {}): Promise
           options.onProgress?.(45, 100, '正在同步向量索引状态...');
         }
 
-        // 传递进度回调给 indexer（embedding API 调用是真正的耗时操作）
-        const indexStats = await indexer.indexFiles(db, allToIndex, (completed, total) => {
-          // 将 embedding 批次进度映射到 45-99 区间（保留 100 给最终完成）
-          const progress = 45 + Math.floor((completed / total) * 54);
-          options.onProgress?.(progress, 100, `正在生成向量嵌入... (${completed}/${total} 批次)`);
-        });
-        stats.vectorIndex = {
-          indexed: indexStats.indexed,
-          deleted: indexStats.deleted,
-          errors: indexStats.errors,
-        };
+        try {
+          // 传递进度回调给 indexer（embedding API 调用是真正的耗时操作）
+          const indexStats = await indexer.indexFiles(db, allToIndex, (completed, total) => {
+            // 将 embedding 批次进度映射到 45-99 区间（保留 100 给最终完成）
+            const progress = 45 + Math.floor((completed / total) * 54);
+            options.onProgress?.(
+              progress,
+              100,
+              `正在生成向量嵌入... (${completed}/${total} 批次)`,
+            );
+          });
+          stats.vectorIndex = {
+            indexed: indexStats.indexed,
+            deleted: indexStats.deleted,
+            errors: indexStats.errors,
+          };
+          if (indexStats.errors > 0) {
+            logger.warn(
+              { errors: indexStats.errors },
+              '向量索引部分失败，请重新创建索引',
+            );
+            options.onProgress?.(100, 100, '向量索引失败，请重新创建索引');
+          }
+        } catch (err) {
+          const error = err as { message?: string; stack?: string };
+          const vectorErrorCount = allToIndex.filter(
+            (r) => (r.status === 'added' || r.status === 'modified') && r.chunks.length > 0,
+          ).length;
+
+          logger.warn(
+            { error: error.message, stack: error.stack, errors: vectorErrorCount },
+            '向量索引失败，保留待索引状态并继续完成扫描；请重新创建索引',
+          );
+          options.onProgress?.(100, 100, '向量索引失败，请重新创建索引');
+
+          stats.vectorIndex = {
+            indexed: 0,
+            deleted: 0,
+            errors: vectorErrorCount,
+          };
+        }
       }
     }
 

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -16,6 +16,7 @@ import {
   setStoredEmbeddingDimensions,
 } from '../db/index.js';
 import { closeAllIndexers, getIndexer } from '../indexer/index.js';
+import { clearProjectExactIndex } from '../search/exactIndex.js';
 import { logger } from '../utils/logger.js';
 import { closeAllVectorStores } from '../vectorStore/index.js';
 import { crawl } from './crawler.js';
@@ -94,9 +95,10 @@ export async function scan(rootPath: string, options: ScanOptions = {}): Promise
       setStoredEmbeddingDimensions(db, currentDimensions);
     }
 
-    // 如果强制重新索引，清空数据库和向量索引
+    // 如果强制重新索引，清空数据库、当前项目 exact 索引和向量索引
     if (forceReindex) {
       clear(db);
+      clearProjectExactIndex(db, projectId);
 
       // 清空向量索引
       if (options.vectorIndex !== false) {

--- a/src/search/SearchService.ts
+++ b/src/search/SearchService.ts
@@ -14,7 +14,7 @@ import { getEmbeddingConfig } from '../config.js';
 import { initDb } from '../db/index.js';
 import { getIndexer, type Indexer } from '../indexer/index.js';
 import { isDebugEnabled, logger } from '../utils/logger.js';
-import type { SearchResult as VectorSearchResult } from '../vectorStore/index.js';
+import type { ChunkRecord, SearchResult as VectorSearchResult } from '../vectorStore/index.js';
 import { getVectorStore, type VectorStore } from '../vectorStore/index.js';
 import { ContextPacker } from './ContextPacker.js';
 import { DEFAULT_CONFIG } from './config.js';
@@ -25,6 +25,8 @@ import {
   searchFilesFts,
   segmentQuery,
 } from './fts.js';
+import { searchExactIndex } from './exactIndex.js';
+import { type ExactTechnicalTermResult } from './exactTechnicalTerms.js';
 import { getGraphExpander } from './GraphExpander.js';
 import type { ContextPack, ScoredChunk, SearchConfig } from './types.js';
 
@@ -74,12 +76,14 @@ export class SearchService {
   /**
    * 构建上下文包（用于问答/生成）
    */
-  async buildContextPack(query: string): Promise<ContextPack> {
+  async buildContextPack(query: string, technicalTerms: string[] = []): Promise<ContextPack> {
     const timingMs: Record<string, number> = {};
     let t0 = Date.now();
 
-    // 1. 混合召回
-    const candidates = await this.hybridRetrieve(query);
+    // 1. 混合召回：query 保留调用方既有语义/词法内容，technical_terms 非空时额外走独立 exact 召回
+    const exactRetrieval = await this.exactRetrieveTechnicalTerms(technicalTerms);
+    const exactReservedSeeds = exactRetrieval.results.slice(0, this.config.exactReservedSeeds);
+    const candidates = await this.hybridRetrieve(query, exactReservedSeeds);
     timingMs.retrieve = Date.now() - t0;
 
     // 2. 取 topM
@@ -90,14 +94,16 @@ export class SearchService {
     const reranked = await this.rerank(query, topM);
     timingMs.rerank = Date.now() - t0;
 
-    // 4. Smart TopK Cutoff
+    // 4. Smart TopK Cutoff，并为 exact 命中保留有限 seed 名额
     t0 = Date.now();
-    const seeds = this.applySmartCutoff(reranked);
+    const seeds = this.limitExactSeeds(
+      this.dedupChunks([...exactReservedSeeds, ...this.applySmartCutoff(reranked)]),
+    );
     timingMs.smartCutoff = Date.now() - t0;
 
     // 5. 扩展（Phase 2 实现）
     t0 = Date.now();
-    const queryTokens = this.extractQueryTokens(query);
+    const queryTokens = this.extractQueryTokens([query, ...technicalTerms].filter(Boolean).join(' '));
     const expanded = await this.expand(seeds, queryTokens);
     timingMs.expand = Date.now() - t0;
 
@@ -107,15 +113,25 @@ export class SearchService {
     const files = await packer.pack([...seeds, ...expanded]);
     timingMs.pack = Date.now() - t0;
 
+    const exactSeedCount = seeds.filter((seed) => seed.source === 'exact').length;
+
     return {
       query,
       seeds,
       expanded,
       files,
+      missingExactTechnicalTerms: exactRetrieval.missingExactTechnicalTerms,
       debug: {
         wVec: this.config.wVec,
         wLex: this.config.wLex,
         timingMs,
+        exactSeedCount,
+        exactCandidateCount: exactRetrieval.results.length,
+        exactScanChunkCount: exactRetrieval.exactScanChunkCount,
+        exactScanElapsedMs: exactRetrieval.exactScanElapsedMs,
+        exactHitsTruncated: exactRetrieval.exactHitsTruncated,
+        exactSearchSource: exactRetrieval.exactSearchSource,
+        skippedTechnicalTerms: exactRetrieval.skippedTechnicalTerms,
       },
     };
   }
@@ -125,8 +141,11 @@ export class SearchService {
   /**
    * 混合召回：向量 + 词法
    */
-  private async hybridRetrieve(query: string): Promise<ScoredChunk[]> {
-    // 并行执行向量和词法召回
+  private async hybridRetrieve(
+    query: string,
+    exactResults: ScoredChunk[] = [],
+  ): Promise<ScoredChunk[]> {
+    // 并行执行向量和词法召回；technical_terms exact 召回由调用方独立传入
     const [vectorResults, lexicalResults] = await Promise.all([
       this.vectorRetrieve(query),
       this.lexicalRetrieve(query),
@@ -136,17 +155,12 @@ export class SearchService {
       {
         vectorCount: vectorResults.length,
         lexicalCount: lexicalResults.length,
+        exactCount: exactResults.length,
       },
       '混合召回完成',
     );
 
-    // 如果词法召回没有结果，直接返回向量结果
-    if (lexicalResults.length === 0) {
-      return vectorResults;
-    }
-
-    // RRF 融合
-    return this.fuse(vectorResults, lexicalResults);
+    return this.fuse(vectorResults, lexicalResults, exactResults);
   }
 
   /**
@@ -352,6 +366,72 @@ export class SearchService {
   }
 
   /**
+   * technical_terms fixed-string exact 召回。
+   *
+   * - technical_terms 非空时才执行
+   * - 不依赖 FTS tokenizer
+   * - 不使用 regex
+   * - 不拆分 term，只有 raw_code / display_code / content 真实包含完整 term 才算 exact
+   */
+  private async exactRetrieveTechnicalTerms(technicalTerms: string[]): Promise<
+    ExactTechnicalTermResult<ChunkRecord> & { results: ScoredChunk[] }
+  > {
+    const emptyResult: ExactTechnicalTermResult<ChunkRecord> & { results: ScoredChunk[] } = {
+      terms: [],
+      skippedTechnicalTerms: [],
+      matches: [],
+      missingExactTechnicalTerms: [],
+      exactScanChunkCount: 0,
+      exactScanElapsedMs: 0,
+      exactHitsTruncated: false,
+      exactSearchSource: [],
+      results: [],
+    };
+
+    if (!this.db || technicalTerms.length === 0) {
+      return emptyResult;
+    }
+
+    const exactMatches = searchExactIndex(this.db, this.projectId, technicalTerms, {
+      exactMaxTerms: this.config.exactMaxTerms,
+      exactMinTermLength: this.config.exactMinTermLength,
+      exactMaxCandidatesPerTerm: this.config.exactMaxCandidatesPerTerm,
+      exactMaxHits: this.config.exactMaxHits,
+    });
+    const matches = exactMatches.hits.map((hit) => ({
+      chunk: hit.chunk,
+      matchedTerms: hit.matchedTerms,
+    }));
+    const results = matches
+      .map(({ chunk, matchedTerms }) => ({
+        filePath: chunk.file_path,
+        chunkIndex: chunk.chunk_index,
+        score: 1 + matchedTerms.length,
+        source: 'exact' as const,
+        record: { ...chunk, _distance: 0 },
+      }))
+      .sort((a, b) => b.score - a.score)
+      .map((chunk, rank) => ({ ...chunk, _rank: rank }));
+
+    logger.debug(
+      {
+        technicalTermCount: exactMatches.terms.length,
+        exactCandidateCount: results.length,
+        exactScanChunkCount: exactMatches.exactScanChunkCount,
+        exactScanElapsedMs: exactMatches.exactScanElapsedMs,
+        exactHitsTruncated: exactMatches.exactHitsTruncated,
+        missingExactTechnicalTerms: exactMatches.missingExactTechnicalTerms,
+        skippedTechnicalTerms: exactMatches.skippedTechnicalTerms,
+        exactSearchSource: exactMatches.exactSearchSource,
+      },
+      'technical_terms exact 召回完成',
+    );
+
+    return { ...exactMatches, matches, results };
+  }
+
+
+  /**
    * 提取查询中的 tokens
    *
    * 直接复用 fts.ts 中的 segmentQuery，确保召回和评分逻辑一致
@@ -404,6 +484,7 @@ export class SearchService {
   private fuse(
     vectorResults: (ScoredChunk & { _rank?: number })[],
     lexicalResults: (ScoredChunk & { _rank?: number })[],
+    exactResults: (ScoredChunk & { _rank?: number })[] = [],
   ): ScoredChunk[] {
     const { rrfK0, wVec, wLex } = this.config;
 
@@ -458,12 +539,34 @@ export class SearchService {
       }
     }
 
+    // 处理 exact 结果：fixed-string 命中直接进入 candidates，并保留 exact 来源
+    for (const result of exactResults) {
+      const key = getKey(result);
+      const exactScore = result.score;
+
+      const existing = fusedScores.get(key);
+      if (existing) {
+        existing.score += exactScore;
+        existing.sources.add('exact');
+      } else {
+        fusedScores.set(key, {
+          score: exactScore,
+          chunk: result,
+          sources: new Set(['exact']),
+        });
+      }
+    }
+
     // 转换为数组并按融合分数排序
     const fused = Array.from(fusedScores.values())
       .map(({ score, chunk, sources }) => ({
         ...chunk,
         score,
-        source: sources.size > 1 ? ('vector' as const) : chunk.source, // 保留原始来源
+        source: sources.has('exact')
+          ? ('exact' as const)
+          : sources.has('lexical')
+            ? ('lexical' as const)
+            : chunk.source, // 来源优先级：exact > lexical > vector
       }))
       .sort((a, b) => b.score - a.score);
 
@@ -655,6 +758,25 @@ export class SearchService {
     return out;
   }
 
+  /**
+   * 对最终 seeds 中的 exact 来源数量做硬上限，避免 exact 候选挤掉其他召回结果。
+   */
+  private limitExactSeeds(list: ScoredChunk[]): ScoredChunk[] {
+    let exactCount = 0;
+    const out: ScoredChunk[] = [];
+
+    for (const chunk of list) {
+      if (chunk.source === 'exact') {
+        if (exactCount >= this.config.exactReservedSeeds) continue;
+        exactCount++;
+      }
+      out.push(chunk);
+    }
+
+    return out;
+  }
+
+
   // 扩展方法
 
   /**
@@ -708,7 +830,6 @@ export class SearchService {
     if (text.length <= maxLen) return text;
 
     const lines = text.split('\n');
-    const _textLower = text.toLowerCase();
 
     // 找命中行（包含任意 query token 的行）
     let hitLineIdx = -1;

--- a/src/search/config.ts
+++ b/src/search/config.ts
@@ -2,6 +2,13 @@
  * 搜索模块默认配置
  */
 
+import {
+  EXACT_MAX_CANDIDATES_PER_TERM,
+  EXACT_MAX_HITS,
+  EXACT_MAX_TERMS,
+  EXACT_MIN_TERM_LENGTH,
+  EXACT_RESERVED_SEEDS,
+} from './exactTechnicalTerms.js';
 import type { SearchConfig } from './types.js';
 
 export const DEFAULT_CONFIG: SearchConfig = {
@@ -37,6 +44,13 @@ export const DEFAULT_CONFIG: SearchConfig = {
   // ContextPacker
   maxSegmentsPerFile: 3,
   maxTotalChars: 48000,
+
+  // Exact substring retrieval
+  exactMaxTerms: EXACT_MAX_TERMS,
+  exactMinTermLength: EXACT_MIN_TERM_LENGTH,
+  exactMaxCandidatesPerTerm: EXACT_MAX_CANDIDATES_PER_TERM,
+  exactMaxHits: EXACT_MAX_HITS,
+  exactReservedSeeds: EXACT_RESERVED_SEEDS,
 
   // Smart TopK
   enableSmartTopK: true,

--- a/src/search/exactIndex.ts
+++ b/src/search/exactIndex.ts
@@ -1,0 +1,348 @@
+import type Database from 'better-sqlite3';
+import type { ChunkRecord } from '../vectorStore/index.js';
+import {
+  EXACT_MAX_CANDIDATES_PER_TERM,
+  EXACT_MAX_HITS,
+  EXACT_MAX_TERMS,
+  EXACT_MIN_TERM_LENGTH,
+  normalizeExactTechnicalTerms,
+} from './exactTechnicalTerms.js';
+
+export interface ExactIndexChunkInput {
+  chunkId: string;
+  filePath: string;
+  fileHash: string;
+  chunkIndex: number;
+  startLine: number;
+  endLine: number;
+  rawStart: number;
+  rawEnd: number;
+  content: string;
+  displayCode: string;
+}
+
+export interface ExactSearchConfig {
+  exactMaxTerms?: number;
+  exactMinTermLength?: number;
+  exactMaxCandidatesPerTerm?: number;
+  exactMaxHits?: number;
+}
+
+export interface ExactSearchHit {
+  chunk: ChunkRecord;
+  matchedTerms: string[];
+}
+
+export interface ExactSearchResult {
+  terms: string[];
+  skippedTechnicalTerms: string[];
+  hits: ExactSearchHit[];
+  missingExactTechnicalTerms: string[];
+  exactScanChunkCount: number;
+  exactScanElapsedMs: number;
+  exactHitsTruncated: boolean;
+  exactSearchSource: string[];
+}
+
+interface ExactChunkRow {
+  project_id: string;
+  chunk_id: string;
+  file_path: string;
+  file_hash: string;
+  chunk_index: number;
+  start_line: number;
+  end_line: number;
+  raw_start: number;
+  raw_end: number;
+  content: string;
+  display_code: string;
+}
+
+export function initExactIndex(db: Database.Database): void {
+  dropLegacyExactIndexIfNeeded(db);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS exact_chunks (
+      project_id TEXT NOT NULL,
+      chunk_id TEXT NOT NULL,
+      file_path TEXT NOT NULL,
+      file_hash TEXT NOT NULL,
+      chunk_index INTEGER NOT NULL,
+      start_line INTEGER NOT NULL,
+      end_line INTEGER NOT NULL,
+      raw_start INTEGER NOT NULL,
+      raw_end INTEGER NOT NULL,
+      content TEXT NOT NULL,
+      display_code TEXT NOT NULL,
+      PRIMARY KEY (project_id, chunk_id)
+    );
+    CREATE TABLE IF NOT EXISTS exact_grams (
+      project_id TEXT NOT NULL,
+      gram TEXT NOT NULL,
+      chunk_id TEXT NOT NULL,
+      PRIMARY KEY (project_id, gram, chunk_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_exact_chunks_project_file_path
+      ON exact_chunks(project_id, file_path);
+    CREATE INDEX IF NOT EXISTS idx_exact_grams_project_gram
+      ON exact_grams(project_id, gram);
+    CREATE INDEX IF NOT EXISTS idx_exact_grams_project_chunk_id
+      ON exact_grams(project_id, chunk_id);
+  `);
+}
+
+function dropLegacyExactIndexIfNeeded(db: Database.Database): void {
+  const shouldDropLegacyExactIndex =
+    (tableExists(db, 'exact_chunks') && !tableHasColumn(db, 'exact_chunks', 'project_id')) ||
+    (tableExists(db, 'exact_grams') && !tableHasColumn(db, 'exact_grams', 'project_id'));
+
+  if (!shouldDropLegacyExactIndex) return;
+
+  const dropLegacyTables = db.transaction(() => {
+    db.exec('DROP TABLE IF EXISTS exact_grams; DROP TABLE IF EXISTS exact_chunks;');
+  });
+  dropLegacyTables();
+}
+
+function tableExists(db: Database.Database, tableName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as { name: string } | undefined;
+  return row !== undefined;
+}
+
+function tableHasColumn(db: Database.Database, tableName: string, columnName: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === columnName);
+}
+
+export function clearProjectExactIndex(db: Database.Database, projectId: string): void {
+  const transaction = db.transaction((id: string) => {
+    db.prepare('DELETE FROM exact_grams WHERE project_id = ?').run(id);
+    db.prepare('DELETE FROM exact_chunks WHERE project_id = ?').run(id);
+  });
+  transaction(projectId);
+}
+
+export function batchDeleteExactIndex(
+  db: Database.Database,
+  projectId: string,
+  filePaths: string[],
+): void {
+  if (filePaths.length === 0) return;
+
+  const deleteGramsStmt = db.prepare(`
+    DELETE FROM exact_grams
+    WHERE project_id = ?
+      AND chunk_id IN (
+        SELECT chunk_id FROM exact_chunks
+        WHERE project_id = ? AND file_path = ?
+      )
+  `);
+  const deleteChunksStmt = db.prepare(
+    'DELETE FROM exact_chunks WHERE project_id = ? AND file_path = ?',
+  );
+
+  const transaction = db.transaction((paths: string[]) => {
+    for (const filePath of paths) {
+      deleteGramsStmt.run(projectId, projectId, filePath);
+      deleteChunksStmt.run(projectId, filePath);
+    }
+  });
+  transaction(filePaths);
+}
+
+export function batchUpsertExactIndex(
+  db: Database.Database,
+  projectId: string,
+  chunks: ExactIndexChunkInput[],
+): void {
+  if (chunks.length === 0) return;
+
+  const insertChunkStmt = db.prepare(`
+    INSERT INTO exact_chunks (
+      project_id, chunk_id, file_path, file_hash, chunk_index, start_line, end_line,
+      raw_start, raw_end, content, display_code
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const insertGramStmt = db.prepare(
+    'INSERT OR IGNORE INTO exact_grams(project_id, gram, chunk_id) VALUES (?, ?, ?)',
+  );
+
+  const transaction = db.transaction((items: ExactIndexChunkInput[]) => {
+    for (const item of items) {
+      insertChunkStmt.run(
+        projectId,
+        item.chunkId,
+        item.filePath,
+        item.fileHash,
+        item.chunkIndex,
+        item.startLine,
+        item.endLine,
+        item.rawStart,
+        item.rawEnd,
+        item.content,
+        item.displayCode,
+      );
+
+      for (const gram of makeChunkTrigrams(item)) {
+        insertGramStmt.run(projectId, gram, item.chunkId);
+      }
+    }
+  });
+  transaction(chunks);
+}
+
+export function searchExactIndex(
+  db: Database.Database,
+  projectId: string,
+  technicalTerms: string[],
+  config: ExactSearchConfig = {},
+): ExactSearchResult {
+  const startedAt = Date.now();
+  const maxTerms = config.exactMaxTerms ?? EXACT_MAX_TERMS;
+  const minTermLength = config.exactMinTermLength ?? EXACT_MIN_TERM_LENGTH;
+  const maxCandidatesPerTerm = config.exactMaxCandidatesPerTerm ?? EXACT_MAX_CANDIDATES_PER_TERM;
+  const maxHits = config.exactMaxHits ?? EXACT_MAX_HITS;
+  const { terms, skippedTechnicalTerms } = normalizeExactTechnicalTerms(
+    technicalTerms,
+    maxTerms,
+    minTermLength,
+  );
+
+  const hitTerms = new Set<string>();
+  const hitsByChunk = new Map<string, ExactSearchHit>();
+  let exactScanChunkCount = 0;
+  let exactHitsTruncated = false;
+
+  for (const term of terms) {
+    if (hitsByChunk.size >= maxHits) {
+      exactHitsTruncated = true;
+      break;
+    }
+
+    const candidates = term.length >= 3
+      ? findCandidatesByGrams(db, projectId, term, maxCandidatesPerTerm)
+      : scanCandidates(db, projectId, term, maxCandidatesPerTerm);
+
+    if (candidates.length >= maxCandidatesPerTerm) {
+      exactHitsTruncated = true;
+    }
+
+    exactScanChunkCount += candidates.length;
+
+    for (const row of candidates) {
+      if (!getSearchableContent(row).includes(term)) continue;
+      hitTerms.add(term);
+      const existing = hitsByChunk.get(row.chunk_id);
+      if (existing) {
+        existing.matchedTerms.push(term);
+      } else {
+        hitsByChunk.set(row.chunk_id, {
+          chunk: rowToChunkRecord(row),
+          matchedTerms: [term],
+        });
+      }
+
+      if (hitsByChunk.size >= maxHits) {
+        exactHitsTruncated = true;
+        break;
+      }
+    }
+  }
+
+  return {
+    terms,
+    skippedTechnicalTerms,
+    hits: Array.from(hitsByChunk.values()),
+    missingExactTechnicalTerms: terms.filter((term) => !hitTerms.has(term)),
+    exactScanChunkCount,
+    exactScanElapsedMs: Date.now() - startedAt,
+    exactHitsTruncated,
+    exactSearchSource: ['exact_chunks'],
+  };
+}
+
+export function makeTrigrams(text: string): string[] {
+  const grams = new Set<string>();
+  for (let i = 0; i <= text.length - 3; i++) {
+    grams.add(text.slice(i, i + 3));
+  }
+  return Array.from(grams);
+}
+
+
+function makeChunkTrigrams(chunk: Pick<ExactIndexChunkInput, 'content' | 'displayCode'>): string[] {
+  return Array.from(new Set([...makeTrigrams(chunk.content), ...makeTrigrams(chunk.displayCode)]));
+}
+
+function findCandidatesByGrams(
+  db: Database.Database,
+  projectId: string,
+  term: string,
+  limit: number,
+): ExactChunkRow[] {
+  const grams = makeTrigrams(term);
+  if (grams.length === 0) return [];
+  const placeholders = grams.map(() => '?').join(', ');
+  const ids = db.prepare(`
+    SELECT chunk_id
+    FROM exact_grams
+    WHERE project_id = ? AND gram IN (${placeholders})
+    GROUP BY chunk_id
+    HAVING COUNT(DISTINCT gram) = ?
+    LIMIT ?
+  `).all(projectId, ...grams, grams.length, limit) as Array<{ chunk_id: string }>;
+  return getExactChunksByIds(db, projectId, ids.map((row) => row.chunk_id));
+}
+
+function scanCandidates(
+  db: Database.Database,
+  projectId: string,
+  term: string,
+  limit: number,
+): ExactChunkRow[] {
+  return db.prepare(`
+    SELECT * FROM exact_chunks
+    WHERE project_id = ? AND (instr(content, ?) > 0 OR instr(display_code, ?) > 0)
+    LIMIT ?
+  `).all(projectId, term, term, limit) as ExactChunkRow[];
+}
+
+function getExactChunksByIds(
+  db: Database.Database,
+  projectId: string,
+  chunkIds: string[],
+): ExactChunkRow[] {
+  if (chunkIds.length === 0) return [];
+  const placeholders = chunkIds.map(() => '?').join(', ');
+  return db.prepare(`
+    SELECT * FROM exact_chunks
+    WHERE project_id = ? AND chunk_id IN (${placeholders})
+  `).all(projectId, ...chunkIds) as ExactChunkRow[];
+}
+
+
+
+function getSearchableContent(chunk: Pick<ExactChunkRow, 'content' | 'display_code'>): string {
+  return `${chunk.content}\n${chunk.display_code}`;
+}
+function rowToChunkRecord(row: ExactChunkRow): ChunkRecord {
+  return {
+    chunk_id: row.chunk_id,
+    file_path: row.file_path,
+    file_hash: row.file_hash,
+    chunk_index: row.chunk_index,
+    vector: [],
+    display_code: row.display_code,
+    vector_text: row.content,
+    language: '',
+    breadcrumb: '',
+    start_index: row.raw_start,
+    end_index: row.raw_end,
+    raw_start: row.raw_start,
+    raw_end: row.raw_end,
+    vec_start: row.raw_start,
+    vec_end: row.raw_end,
+  };
+}

--- a/src/search/exactTechnicalTerms.test.ts
+++ b/src/search/exactTechnicalTerms.test.ts
@@ -1,0 +1,350 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  batchDeleteExactIndex,
+  batchUpsertExactIndex,
+  clearProjectExactIndex,
+  initExactIndex,
+  searchExactIndex,
+} from './exactIndex.js';
+import { SearchService } from './SearchService.js';
+import type { ScoredChunk } from './types.js';
+import { collectExactTechnicalTermMatches, EXACT_RESERVED_SEEDS, type SearchableChunk } from './exactTechnicalTerms.js';
+
+function chunk(chunk_index: number, text: string): SearchableChunk {
+  return {
+    file_path: `fixture-${chunk_index}.txt`,
+    chunk_index,
+    display_code: text,
+  };
+}
+
+function withExactDb(
+  rows: Array<{ chunkId: string; content: string; displayCode?: string }>,
+  run: (db: Database.Database) => void,
+): void {
+  const db = new Database(':memory:');
+  try {
+    initExactIndex(db);
+    batchUpsertExactIndex(
+      db,
+      'test-project',
+      rows.map((row, index) => ({
+        chunkId: row.chunkId,
+        filePath: `fixture-${index}.txt`,
+        fileHash: `hash-${index}`,
+        chunkIndex: index,
+        startLine: 1,
+        endLine: 1,
+        rawStart: 0,
+        rawEnd: row.content.length,
+        content: row.content,
+        displayCode: row.displayCode ?? row.content,
+      })),
+    );
+    run(db);
+  } finally {
+    db.close();
+  }
+}
+
+describe('collectExactTechnicalTermMatches fixed-string fixtures', () => {
+  it('does not match @ControllerAdvice as @RestController', () => {
+    const result = collectExactTechnicalTermMatches(
+      [chunk(0, '@RestController\nclass DemoController {}')],
+      ['@ControllerAdvice'],
+    );
+
+    assert.equal(result.matches.length, 0);
+    assert.deepEqual(result.missingExactTechnicalTerms, ['@ControllerAdvice']);
+  });
+
+  it('does not match useQuery() as useQueryClient', () => {
+    const result = collectExactTechnicalTermMatches(
+      [chunk(0, 'const client = useQueryClient();')],
+      ['useQuery()'],
+    );
+
+    assert.equal(result.matches.length, 0);
+    assert.deepEqual(result.missingExactTechnicalTerms, ['useQuery()']);
+  });
+
+  it('does not match R.failed only because failed is present', () => {
+    const result = collectExactTechnicalTermMatches(
+      [chunk(0, 'return failed(error);')],
+      ['R.failed'],
+    );
+
+    assert.equal(result.matches.length, 0);
+    assert.deepEqual(result.missingExactTechnicalTerms, ['R.failed']);
+  });
+
+  it('puts nonexistent terms into missingExactTechnicalTerms', () => {
+    const result = collectExactTechnicalTermMatches([chunk(0, 'const ok = true;')], ['NotThere']);
+
+    assert.equal(result.matches.length, 0);
+    assert.deepEqual(result.missingExactTechnicalTerms, ['NotThere']);
+  });
+});
+
+
+
+describe('searchExactIndex SQLite-backed fixed-string fixtures', () => {
+  it('does not match @ControllerAdvice as @RestController', () => {
+    withExactDb([{ chunkId: 'c0', content: '@RestController\nclass DemoController {}' }], (db) => {
+      const result = searchExactIndex(db, 'test-project', ['@ControllerAdvice']);
+
+      assert.equal(result.hits.length, 0);
+      assert.deepEqual(result.missingExactTechnicalTerms, ['@ControllerAdvice']);
+    });
+  });
+
+  it('does not match useQuery() as useQueryClient', () => {
+    withExactDb([{ chunkId: 'c0', content: 'const client = useQueryClient();' }], (db) => {
+      const result = searchExactIndex(db, 'test-project', ['useQuery()']);
+
+      assert.equal(result.hits.length, 0);
+      assert.deepEqual(result.missingExactTechnicalTerms, ['useQuery()']);
+    });
+  });
+
+  it('does not match R.failed only because failed is present', () => {
+    withExactDb([{ chunkId: 'c0', content: 'return failed(error);' }], (db) => {
+      const result = searchExactIndex(db, 'test-project', ['R.failed']);
+
+      assert.equal(result.hits.length, 0);
+      assert.deepEqual(result.missingExactTechnicalTerms, ['R.failed']);
+    });
+  });
+
+  it('puts nonexistent terms into missingExactTechnicalTerms', () => {
+    withExactDb([{ chunkId: 'c0', content: 'const ok = true;' }], (db) => {
+      const result = searchExactIndex(db, 'test-project', ['NotThere']);
+
+      assert.equal(result.hits.length, 0);
+      assert.deepEqual(result.missingExactTechnicalTerms, ['NotThere']);
+    });
+  });
+
+  it('finds exact raw substring hits via exact_grams candidates', () => {
+    withExactDb([{ chunkId: 'c0', content: 'const value = useQuery();' }], (db) => {
+      const result = searchExactIndex(db, 'test-project', ['useQuery()']);
+
+      assert.equal(result.hits.length, 1);
+      assert.equal(result.hits[0].chunk.chunk_id, 'c0');
+      assert.deepEqual(result.missingExactTechnicalTerms, []);
+      assert.deepEqual(result.exactSearchSource, ['exact_chunks']);
+    });
+  });
+
+  it('finds 2-character terms that appear only in displayCode via scanCandidates', () => {
+    withExactDb([{ chunkId: 'c0', content: 'const value = noDisplayOnlyTerm;', displayCode: 'xy' }], (db) => {
+      const result = searchExactIndex(db, 'test-project', ['xy']);
+
+      assert.equal(result.hits.length, 1);
+      assert.equal(result.hits[0].chunk.chunk_id, 'c0');
+      assert.deepEqual(result.hits[0].matchedTerms, ['xy']);
+      assert.deepEqual(result.missingExactTechnicalTerms, []);
+    });
+  });
+
+});
+
+
+describe('exact index legacy schema migration', () => {
+  it('recreates legacy exact tables without project_id and keeps exact index usable', () => {
+    const db = new Database(':memory:');
+    try {
+      db.exec(`
+        CREATE TABLE exact_chunks (
+          chunk_id TEXT PRIMARY KEY,
+          file_path TEXT NOT NULL,
+          file_hash TEXT NOT NULL,
+          chunk_index INTEGER NOT NULL,
+          start_line INTEGER NOT NULL,
+          end_line INTEGER NOT NULL,
+          raw_start INTEGER NOT NULL,
+          raw_end INTEGER NOT NULL,
+          content TEXT NOT NULL,
+          display_code TEXT NOT NULL
+        );
+        CREATE TABLE exact_grams (
+          gram TEXT NOT NULL,
+          chunk_id TEXT NOT NULL,
+          PRIMARY KEY (gram, chunk_id)
+        );
+      `);
+
+      initExactIndex(db);
+
+      const exactChunkColumns = db.prepare('PRAGMA table_info(exact_chunks)').all() as Array<{ name: string }>;
+      const exactGramColumns = db.prepare('PRAGMA table_info(exact_grams)').all() as Array<{ name: string }>;
+      assert.equal(exactChunkColumns.some((column) => column.name === 'project_id'), true);
+      assert.equal(exactGramColumns.some((column) => column.name === 'project_id'), true);
+
+      batchUpsertExactIndex(db, 'test-project', [
+        {
+          chunkId: 'migrated-c0',
+          filePath: 'migrated/file.ts',
+          fileHash: 'migrated-hash',
+          chunkIndex: 0,
+          startLine: 1,
+          endLine: 1,
+          rawStart: 0,
+          rawEnd: 28,
+          content: 'const migratedExactTerm = true;',
+          displayCode: 'const migratedExactTerm = true;',
+        },
+      ]);
+
+      const result = searchExactIndex(db, 'test-project', ['migratedExactTerm']);
+      assert.equal(result.hits.length, 1);
+      assert.equal(result.hits[0].chunk.chunk_id, 'migrated-c0');
+      assert.deepEqual(result.missingExactTechnicalTerms, []);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+
+
+describe('exact index project isolation', () => {
+  function upsertProjectChunk(db: Database.Database, projectId: string, content: string): void {
+    batchUpsertExactIndex(db, projectId, [
+      {
+        chunkId: 'shared-chunk-id',
+        filePath: 'shared/file.ts',
+        fileHash: `${projectId}-hash`,
+        chunkIndex: 0,
+        startLine: 1,
+        endLine: 1,
+        rawStart: 0,
+        rawEnd: content.length,
+        content,
+        displayCode: content,
+      },
+    ]);
+  }
+
+  it('keeps search, file delete, and project clear scoped by project_id', () => {
+    const db = new Database(':memory:');
+    try {
+      initExactIndex(db);
+      upsertProjectChunk(db, 'projectA', 'const value = projectAOnlyTerm;');
+      upsertProjectChunk(db, 'projectB', 'const value = projectBOnlyTerm;');
+
+      const projectASearch = searchExactIndex(db, 'projectA', ['projectAOnlyTerm', 'projectBOnlyTerm']);
+      assert.deepEqual(
+        projectASearch.hits.map((hit) => hit.chunk.file_path),
+        ['shared/file.ts'],
+      );
+      assert.deepEqual(projectASearch.hits[0].matchedTerms, ['projectAOnlyTerm']);
+      assert.deepEqual(projectASearch.missingExactTechnicalTerms, ['projectBOnlyTerm']);
+
+      batchDeleteExactIndex(db, 'projectA', ['shared/file.ts']);
+      assert.equal(searchExactIndex(db, 'projectA', ['projectAOnlyTerm']).hits.length, 0);
+      assert.equal(searchExactIndex(db, 'projectB', ['projectBOnlyTerm']).hits.length, 1);
+
+      upsertProjectChunk(db, 'projectA', 'const value = projectAOnlyTerm;');
+      clearProjectExactIndex(db, 'projectA');
+      assert.equal(searchExactIndex(db, 'projectA', ['projectAOnlyTerm']).hits.length, 0);
+      assert.equal(searchExactIndex(db, 'projectB', ['projectBOnlyTerm']).hits.length, 1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+
+describe('exact index force cleanup', () => {
+  it('clears only the current project exact index rows', () => {
+    const db = new Database(':memory:');
+    try {
+      initExactIndex(db);
+      const insert = (projectId: string, content: string) => {
+        batchUpsertExactIndex(db, projectId, [
+          {
+            chunkId: `${projectId}-chunk`,
+            filePath: 'src/shared.ts',
+            fileHash: `${projectId}-hash`,
+            chunkIndex: 0,
+            startLine: 1,
+            endLine: 1,
+            rawStart: 0,
+            rawEnd: content.length,
+            content,
+            displayCode: content,
+          },
+        ]);
+      };
+
+      insert('projectA', 'const value = projectAForceTerm;');
+      insert('projectB', 'const value = projectBForceTerm;');
+
+      clearProjectExactIndex(db, 'projectA');
+
+      assert.equal(searchExactIndex(db, 'projectA', ['projectAForceTerm']).hits.length, 0);
+      assert.equal(searchExactIndex(db, 'projectB', ['projectBForceTerm']).hits.length, 1);
+      assert.equal(
+        (db.prepare('SELECT COUNT(*) AS count FROM exact_chunks WHERE project_id = ?').get('projectA') as { count: number }).count,
+        0,
+      );
+      assert.equal(
+        (db.prepare('SELECT COUNT(*) AS count FROM exact_grams WHERE project_id = ?').get('projectA') as { count: number }).count,
+        0,
+      );
+      assert.ok(
+        (db.prepare('SELECT COUNT(*) AS count FROM exact_chunks WHERE project_id = ?').get('projectB') as { count: number }).count > 0,
+      );
+      assert.ok(
+        (db.prepare('SELECT COUNT(*) AS count FROM exact_grams WHERE project_id = ?').get('projectB') as { count: number }).count > 0,
+      );
+    } finally {
+      db.close();
+    }
+  });
+});
+
+
+describe('SearchService exact seed limit', () => {
+  it('limits final exact seeds with EXACT_RESERVED_SEEDS', () => {
+    const service = new SearchService('test-project', 'test-path') as unknown as {
+      limitExactSeeds: (list: ScoredChunk[]) => ScoredChunk[];
+    };
+    const makeScoredChunk = (index: number, source: ScoredChunk['source']): ScoredChunk => ({
+      filePath: `fixture-${index}.ts`,
+      chunkIndex: index,
+      score: 1,
+      source,
+      record: {
+        chunk_id: `chunk-${index}`,
+        file_path: `fixture-${index}.ts`,
+        file_hash: `hash-${index}`,
+        chunk_index: index,
+        vector: [],
+        display_code: 'const value = manyExactHits;',
+        vector_text: 'const value = manyExactHits;',
+        language: 'typescript',
+        breadcrumb: '',
+        start_index: 0,
+        end_index: 1,
+        raw_start: 0,
+        raw_end: 1,
+        vec_start: 0,
+        vec_end: 1,
+        _distance: 0,
+      },
+    });
+
+    const manyExact = Array.from({ length: EXACT_RESERVED_SEEDS + 5 }, (_, index) =>
+      makeScoredChunk(index, 'exact'),
+    );
+    const vectorSeed = makeScoredChunk(999, 'vector');
+    const seeds = service.limitExactSeeds([...manyExact, vectorSeed]);
+
+    assert.equal(seeds.filter((seed) => seed.source === 'exact').length, EXACT_RESERVED_SEEDS);
+    assert.equal(seeds.some((seed) => seed.source === 'vector'), true);
+  });
+});

--- a/src/search/exactTechnicalTerms.ts
+++ b/src/search/exactTechnicalTerms.ts
@@ -1,0 +1,139 @@
+export const EXACT_MIN_TERM_LENGTH = 2;
+export const EXACT_MAX_TERMS = 20;
+export const EXACT_MAX_HITS = 200;
+export const EXACT_MAX_CANDIDATES_PER_TERM = 50;
+export const EXACT_RESERVED_SEEDS = 10;
+
+export type SearchableChunk = {
+  file_path: string;
+  chunk_index: number;
+  display_code?: string;
+  raw_code?: string;
+  content?: string;
+};
+
+export interface ExactTechnicalTermMatch<T extends SearchableChunk> {
+  chunk: T;
+  matchedTerms: string[];
+}
+
+export interface ExactTechnicalTermResult<T extends SearchableChunk> {
+  terms: string[];
+  skippedTechnicalTerms: string[];
+  matches: ExactTechnicalTermMatch<T>[];
+  missingExactTechnicalTerms: string[];
+  exactScanChunkCount: number;
+  exactScanElapsedMs: number;
+  exactHitsTruncated: boolean;
+  exactSearchSource: string[];
+}
+
+export function collectExactTechnicalTermMatches<T extends SearchableChunk>(
+  chunks: T[],
+  technicalTerms: string[],
+): ExactTechnicalTermResult<T> {
+  const startedAt = Date.now();
+  const { terms, skippedTechnicalTerms } = normalizeExactTechnicalTerms(technicalTerms);
+  const matches: ExactTechnicalTermMatch<T>[] = [];
+  const hitTerms = new Set<string>();
+  const hitsPerTerm = new Map<string, number>();
+  const exactSearchSource = new Set<string>();
+  let exactScanChunkCount = 0;
+  let totalHits = 0;
+  let exactHitsTruncated = false;
+
+  if (terms.length === 0) {
+    return finish();
+  }
+
+  for (const chunk of chunks) {
+    exactScanChunkCount++;
+    const fields = getExactSearchFields(chunk);
+    const matchedTerms: string[] = [];
+
+    for (const term of terms) {
+      if ((hitsPerTerm.get(term) ?? 0) >= EXACT_MAX_CANDIDATES_PER_TERM) {
+        exactHitsTruncated = true;
+        continue;
+      }
+
+      const hitField = fields.find((field) => field.text.includes(term));
+      if (!hitField) continue;
+
+      if (totalHits >= EXACT_MAX_HITS) {
+        exactHitsTruncated = true;
+        break;
+      }
+
+      matchedTerms.push(term);
+      hitTerms.add(term);
+      exactSearchSource.add(hitField.source);
+      hitsPerTerm.set(term, (hitsPerTerm.get(term) ?? 0) + 1);
+      totalHits++;
+    }
+
+    if (matchedTerms.length > 0) {
+      matches.push({ chunk, matchedTerms });
+    }
+
+    if (exactHitsTruncated && totalHits >= EXACT_MAX_HITS) {
+      break;
+    }
+  }
+
+  return finish();
+
+  function finish(): ExactTechnicalTermResult<T> {
+    return {
+      terms,
+      skippedTechnicalTerms,
+      matches,
+      missingExactTechnicalTerms: terms.filter((term) => !hitTerms.has(term)),
+      exactScanChunkCount,
+      exactScanElapsedMs: Date.now() - startedAt,
+      exactHitsTruncated,
+      exactSearchSource: Array.from(exactSearchSource),
+    };
+  }
+}
+
+export function normalizeExactTechnicalTerms(
+  technicalTerms: string[],
+  maxTerms = EXACT_MAX_TERMS,
+  minTermLength = EXACT_MIN_TERM_LENGTH,
+): {
+  terms: string[];
+  skippedTechnicalTerms: string[];
+} {
+  const seen = new Set<string>();
+  const terms: string[] = [];
+  const skippedTechnicalTerms: string[] = [];
+
+  for (const rawTerm of technicalTerms) {
+    const term = rawTerm.trim();
+    if (!term || seen.has(term)) continue;
+    seen.add(term);
+
+    if (term.length < minTermLength) {
+      skippedTechnicalTerms.push(term);
+      continue;
+    }
+
+    if (terms.length >= maxTerms) {
+      skippedTechnicalTerms.push(term);
+      continue;
+    }
+
+    terms.push(term);
+  }
+
+  return { terms, skippedTechnicalTerms };
+}
+
+function getExactSearchFields(chunk: SearchableChunk): Array<{ source: string; text: string }> {
+  const fields: Array<{ source: string; text: string }> = [];
+  if (chunk.raw_code) fields.push({ source: 'raw_code', text: chunk.raw_code });
+  if (chunk.display_code) fields.push({ source: 'display_code', text: chunk.display_code });
+  if (chunk.content) fields.push({ source: 'content', text: chunk.content });
+  return fields;
+}

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -43,6 +43,13 @@ export interface SearchConfig {
   maxSegmentsPerFile: number;
   maxTotalChars: number;
 
+  // Exact substring retrieval
+  exactMaxTerms: number;
+  exactMinTermLength: number;
+  exactMaxCandidatesPerTerm: number;
+  exactMaxHits: number;
+  exactReservedSeeds: number;
+
   // === Smart TopK ===
   /** 是否启用智能 TopK 策略 */
   enableSmartTopK: boolean;
@@ -85,7 +92,7 @@ export interface SearchConfig {
 // ===========================================
 
 /** Chunk 来源类型 */
-export type ChunkSource = 'vector' | 'lexical' | 'neighbor' | 'breadcrumb' | 'import';
+export type ChunkSource = 'vector' | 'lexical' | 'exact' | 'neighbor' | 'breadcrumb' | 'import';
 
 /** 带得分的 Chunk */
 export interface ScoredChunk {
@@ -134,10 +141,19 @@ export interface ContextPack {
     filePath: string;
     segments: Segment[];
   }>;
+  /** technical_terms 中未在 raw/display/content 中 fixed-string 命中的术语 */
+  missingExactTechnicalTerms?: string[];
   /** 调试信息 */
   debug?: {
     wVec: number;
     wLex: number;
     timingMs: Record<string, number>;
+    exactSeedCount?: number;
+    exactCandidateCount?: number;
+    exactScanChunkCount?: number;
+    exactScanElapsedMs?: number;
+    exactHitsTruncated?: boolean;
+    exactSearchSource?: string[];
+    skippedTechnicalTerms?: string[];
   };
 }


### PR DESCRIPTION
本 PR 增加了 Voyage embedding provider 支持，并增强了代码检索中 `technical_terms` 的精确召回能力。

主要内容包括：

* 支持 Voyage embedding 请求格式。
* 为 Voyage 区分索引阶段和查询阶段的 `input_type`。
* 支持 Voyage 可选的 `output_dimension` 和 `output_dtype`。
* 新增基于 SQLite 的 exact substring index，用于 `technical_terms` 精确召回。
* exact index 按 `project_id` 隔离，避免不同项目互相污染。
* 增强索引一致性，避免 exact index 写入失败后被误标记为成功。
* 在 MCP / CLI 输出中增加 exact retrieval 诊断信息。
* 增加 fixed-string exact retrieval、project isolation、force cleanup、legacy migration、失败重试等测试。
* 更新 Voyage 配置和 exact retrieval 相关文档。

## 主要改动

### 1. Voyage embedding provider

新增 Voyage embedding provider 兼容逻辑。

当配置：

```bash
EMBEDDINGS_PROVIDER=voyage
```

或 `EMBEDDINGS_BASE_URL` 指向 Voyage endpoint 时，使用 Voyage 请求格式。

Voyage 请求行为：

* 索引阶段发送 `input_type=document`。
* 查询阶段发送 `input_type=query`。
* 默认发送 `output_dtype=float`。
* 仅在显式配置 `EMBEDDINGS_OUTPUT_DIMENSION` 时发送 `output_dimension`。
* 不发送 OpenAI-compatible 的 `encoding_format`。

非 Voyage provider，例如 SiliconFlow / OpenAI-compatible：

* 保持原有 `encoding_format=float` 行为。
* 不发送 Voyage 专属字段。

同时补充说明：

* `EMBEDDINGS_DIMENSIONS` 是本地向量库维度。
* `EMBEDDINGS_OUTPUT_DIMENSION` 是 Voyage API 可选输出维度。
* 两者需要与实际返回向量维度保持一致。

### 2. technical_terms fixed-string exact retrieval

增强 `technical_terms` 处理逻辑。

之前 `technical_terms` 主要拼接进 query。现在会额外执行 fixed-string exact retrieval，用于精确召回包含完整术语的代码片段。

支持包含特殊符号的术语，例如：

```text
@ControllerAdvice
@ExceptionHandler
R.failed
e.getMessage
useQuery()
```

exact retrieval 特点：

* 按完整 substring 匹配。
* 不使用正则。
* 不依赖 FTS tokenizer。
* 不拆分 term。
* 不把部分字符串当作命中。
* 最终通过 raw content / display code 做 fixed-string 二次确认。

因此：

* `@ControllerAdvice` 不会误命中 `@RestController`。
* `useQuery()` 不会误命中 `useQueryClient`。
* `R.failed` 不会仅因为出现 `failed` 而命中。

### 3. SQLite exact substring index

新增 SQLite-backed exact substring index，用于提升 exact retrieval 的稳定性和性能。

新增或使用的结构包括：

* `exact_chunks`
* `exact_grams`

特性：

* 使用现有 SQLite / better-sqlite3，不需要额外安装数据库。
* exact index 按 `project_id` 隔离。
* 文件修改时会删除旧 exact index 并写入新内容。
* 文件删除时会清理对应 exact index。
* `--force` 重建索引时会清理当前 project 的 exact index。
* 兼容旧 schema，旧表缺少 `project_id` 时会 drop 后重建。
* 短 term fallback 会同时检查 `content` 和 `display_code`。

### 4. 索引一致性修复

修复 exact index 写入失败时可能造成的部分成功状态。

现在如果 exact index 写入失败：

* 会记录错误日志。
* 会清理本批文件的 `vector_index_hash`。
* 不会把本批文件标记为已成功索引。
* 返回 errors。
* 下一次增量索引会重新尝试。

这样可以避免：

```text
向量写入成功
exact index 写入失败
但文件被标记为已索引
后续增量索引跳过
```

导致 exact retrieval 长期缺失的问题。

### 5. MCP / CLI exact retrieval 诊断信息

MCP / CLI 输出增加 exact retrieval 诊断信息，便于判断 technical_terms 是否真正精确命中。

可能包含：

```text
Missing exact technical terms: ...
Exact: seeds=..., candidates=..., scanned=..., elapsed=...ms, truncated=...
Skipped exact technical terms: ...
```

含义：

* `Missing exact technical terms`：传入的术语没有 exact 命中。
* `seeds`：最终进入上下文的 exact seed 数量。
* `candidates`：exact retrieval 候选数量。
* `scanned`：扫描或检查过的 chunk 数量。
* `elapsed`：exact retrieval 耗时。
* `truncated`：结果是否因上限被截断。
* `Skipped exact technical terms`：因过短或超过数量限制被跳过的术语。

### 6. 测试覆盖

新增或补充测试覆盖：

* fixed-string exact matching。
* `@ControllerAdvice` 不误命中 `@RestController`。
* `useQuery()` 不误命中 `useQueryClient`。
* `R.failed` 不误命中 `failed`。
* missing exact technical terms。
* SQLite-backed exact index 查询。
* `project_id` 隔离。
* force cleanup。
* legacy exact schema migration。
* 短 term 只存在于 `display_code` 的场景。
* exact seed 数量限制。
* exact index 写入失败不更新 `vector_index_hash`。
* exact index 写入失败后下一次可重试。
* 重试成功后 exact index 可正常检索。

### 7. 文档更新

更新文档说明：

* Voyage embedding 配置。
* `EMBEDDINGS_OUTPUT_DIMENSION`。
* `EMBEDDINGS_OUTPUT_DTYPE`。
* `EMBEDDINGS_DIMENSIONS` 与 API 返回维度的关系。
* technical_terms exact retrieval 行为。
* SQLite exact substring index。
* MCP / CLI exact diagnostics。
* `IGNORE_PATTERNS` 建议。

## 验证

已执行或建议执行：

```bash
pnpm build
```

```bash
npx vitest run src/search/exactTechnicalTerms.test.ts src/indexer/index.test.ts
```

手动 fixture 验证：

* `@ControllerAdvice` 只 exact 命中包含 `@ControllerAdvice` 的文件。
* `useQuery()` 不 exact 命中 `useQueryClient`。
* `R.failed` 不 exact 命中普通 `failed`。
* 不存在的术语会出现在 `missingExactTechnicalTerms`。

真实 workspace 验证：

* exact retrieval 可以稳定命中包含目标 technical terms 的代码。
* `missingExactTechnicalTerms` 行为符合预期。
* `exactSeedCount`、`exactCandidateCount`、`exactHitsTruncated` 等诊断信息正常输出。
* vector / lexical fallback 仍可正常工作。

## 注意事项

更换 embedding provider、embedding model、输出维度或输出 dtype 后，需要重新建立向量索引：

```bash
contextweaver index --force
```

仅更换 rerank 配置通常不需要重新索引，因为 rerank 只影响搜索阶段排序。
